### PR TITLE
Get My Usages Endpoint

### DIFF
--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -6,6 +6,7 @@ from .routes import (
     auth,
     machine_groups,
     machine_types,
+    machine_usages,
     machines,
     officer_actions,
     public,
@@ -20,6 +21,7 @@ api_router = APIRouter()
 api_router.include_router(auth.router, tags=["auth"])
 api_router.include_router(machine_groups.router, tags=["machine_groups"])
 api_router.include_router(machine_types.router, tags=["machine_types"])
+api_router.include_router(machine_usages.router, tags=["machine_usages"])
 api_router.include_router(machines.router, tags=["machines"])
 api_router.include_router(officer_actions.router, tags=["officer_actions"])
 api_router.include_router(public.router, tags=["public"])

--- a/backend/api/routes/machine_usages.py
+++ b/backend/api/routes/machine_usages.py
@@ -1,0 +1,60 @@
+""" Machine Usage endpoints. """
+
+from typing import Annotated, Literal
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.orm import InstrumentedAttribute, selectinload
+
+from models.machine_usage import MachineUsage
+from schemas.responses import UsageResponse
+
+from ..deps import DBSession, PermittedUserChecker
+from models.user import User
+
+router = APIRouter()
+
+@router.get("/usages/me")
+async def get_my_usages(
+    session: DBSession,
+    current_user: Annotated[
+        User, Depends(PermittedUserChecker(set()))
+    ],
+    limit: int = 20,
+    offset: int = 0,
+    order_by: Literal[
+        "time_started",
+        "cost",
+    ] = "time_started",
+    descending: bool = False,
+):
+    """Fetch machine usage records for current user."""
+
+    attr_key_map: dict[str, InstrumentedAttribute] = {
+        "time_started": MachineUsage.time_started,
+        "cost": MachineUsage.cost,
+    }
+    order_determinant = attr_key_map[order_by]
+    if descending:
+        order_determinant = order_determinant.desc()
+
+    machine_usages = (
+        await session.scalars(
+            select(MachineUsage)
+            .options(selectinload(MachineUsage.machine))
+            .options(selectinload(MachineUsage.semester))
+            .where(MachineUsage.user_id == current_user.id)
+            .order_by(order_determinant)
+            .offset(offset)
+            .fetch(limit)
+        )
+    ).all()
+
+    return [
+        UsageResponse(
+            machine_name=usage.machine.name,
+            semester=f"{usage.semester.semester_type} {usage.semester.calendar_year}" if usage.semester else "<None>",
+            time_started=usage.time_started,
+            cost=usage.cost,
+        )
+        for usage in machine_usages
+    ]

--- a/backend/api/routes/machine_usages.py
+++ b/backend/api/routes/machine_usages.py
@@ -54,7 +54,7 @@ async def get_my_usages(
     return [
         UsageResponse(
             machine_name=usage.machine.name,
-            semester=f"{usage.semester.semester_type} {usage.semester.calendar_year}" if usage.semester else "<None>",
+            semester=f"{usage.semester.semester_type} {usage.semester.calendar_year}" if usage.semester else None,
             time_started=usage.time_started,
             cost=usage.cost,
         )

--- a/backend/api/routes/machine_usages.py
+++ b/backend/api/routes/machine_usages.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.orm import InstrumentedAttribute, selectinload
 
+from models.machine import Machine
 from models.machine_usage import MachineUsage
 from schemas.responses import UsageResponse
 
@@ -32,6 +33,7 @@ async def get_my_usages(
     attr_key_map: dict[str, InstrumentedAttribute] = {
         "time_started": MachineUsage.time_started,
         "cost": MachineUsage.cost,
+        "name": Machine.name,
     }
     order_determinant = attr_key_map[order_by]
     if descending:

--- a/backend/schemas/responses.py
+++ b/backend/schemas/responses.py
@@ -165,7 +165,7 @@ class MachineUsageSchema(BaseResponse):
     maintenance_mode: bool
 
 class UsageResponse(BaseResponse):
-    semester: str
+    semester: str | None
     time_started: datetime
     machine_name: str
     cost: Decimal

--- a/backend/schemas/responses.py
+++ b/backend/schemas/responses.py
@@ -164,6 +164,12 @@ class MachineUsageSchema(BaseResponse):
 
     maintenance_mode: bool
 
+class UsageResponse(BaseResponse):
+    semester: str
+    time_started: datetime
+    machine_name: str
+    cost: Decimal
+
 
 class MachineInfo(BaseModel):
     id: UUID4


### PR DESCRIPTION
Self-explanatory. Currently paginated and sortable by time started, cost, and machine name. Threw machine name in last minute, so if it doesn't work properly just let me know and I'll patch it. Was gonna do a sort by semester, but realistically you can just do a time_started sort and that should be the same for 99% of cases.