### PR TITLE
Bug Fix: Added sort to machine status

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -31,12 +31,14 @@ async def get_machines_status(
         )
     ).all()
 
-    machines.sort(key=lambda x: x.group_id if x.group_id is not None else "")
+    group_dict = {}
+    for machine in machines:
+        key = machine.group_id if machine.group_id is not None else ""
+        group_dict.setdefault(key, []).append(machine)
 
-    group_dict = groupby(machines, key=lambda x: x.group_id)
     group_list = []
     loner_list = []
-    for _, group in group_dict:
+    for _, group in group_dict.items():
         machines = list(group)
         machines.sort(key=lambda machine: machine.name)
 

--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -25,17 +25,20 @@ async def get_machines_status(
     machines = (
         await session.scalars(
             select(Machine)
-            .options(selectinload(Machine.active_usage))
             .options(selectinload(Machine.group))
+            .options(selectinload(Machine.active_usage))
             .options(selectinload(Machine.type))
         )
     ).all()
+
+    machines.sort(key=lambda x: x.group_id if x.group_id is not None else "")
 
     group_dict = groupby(machines, key=lambda x: x.group_id)
     group_list = []
     loner_list = []
     for _, group in group_dict:
         machines = list(group)
+        machines.sort(key=lambda machine: machine.name)
 
         machine_statuses = [
             MachineStatus.model_validate(


### PR DESCRIPTION
Sorts machines by group before groupby so that machines in the same group stay together. Also sort each machinegroup list of machines so they're always returned in the same consistent alphabetical order