### PR TITLE
Bug fix: Scrolling for tables

### DIFF
--- a/frontend/src/components/MyForge/styles/Table.scss
+++ b/frontend/src/components/MyForge/styles/Table.scss
@@ -30,7 +30,10 @@
     margin-top: 20px;
     width: 100%;
     overflow-x: auto;
-    padding: 0 2rem 0 2rem;
+    padding: 0 2rem 0 2rem;    
+    max-height: 60vh;
+    overflow-y: auto;
+    position: relative;
 
     table {
         width: 100%;


### PR DESCRIPTION
Added vertical scrolling to the Table component which is used in all the object pages because the bottom of the table and the pagination buttons had previously been getting cut off and were unreachable.

**Before:**
<img width="1699" height="804" alt="image" src="https://github.com/user-attachments/assets/c9ccce50-0704-488f-a84f-91593edb965c" />

**After:**
<img width="1709" height="798" alt="image" src="https://github.com/user-attachments/assets/14cd4037-ead1-4769-83ac-cbf2dfbc5b2b" />
