### PR TITLE
Charge sheets

### DIFF
--- a/backend/api/routes/officer_actions.py
+++ b/backend/api/routes/officer_actions.py
@@ -1,18 +1,19 @@
+from decimal import Decimal
 from datetime import datetime
 from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import UUID4
-from sqlalchemy import and_, select
+from sqlalchemy import and_, select, func
 from sqlalchemy.orm import selectinload
 
 from models.audit_log import AuditLog
-from models.machine import Machine
+from models.machine_usage import MachineUsage
 from models.semester import Semester
 from models.state import State
 from models.user import User
 from schemas.enums import LogType, Permissions, SemesterType
-from schemas.requests import ActivateSemesterRequest
-from schemas.responses import CreateResponse
+from schemas.requests import ActivateSemesterRequest, GetChargeSheetsRequest
+from schemas.responses import CreateResponse, UserChargeResponse
 
 from ..deps import DBSession, PermittedUserChecker
 
@@ -111,3 +112,62 @@ async def set_semester(
     )
     session.add(audit_log)
     await session.commit()
+
+
+@router.post("/exec/get_charges")
+async def get_charge_sheet(
+    request: GetChargeSheetsRequest,
+    session: DBSession,
+    current_user: Annotated[
+        User, Depends(PermittedUserChecker({Permissions.CAN_GET_CHARGES}))
+    ],
+):
+    """Create and return the charge sheet for the provided semester."""
+
+    semester = await session.scalar(
+        select(Semester).where(Semester.id == request.semester_id)
+    )
+    if not semester:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Could not find a semester with the provided ID",
+        )
+
+    users = (
+        await session.scalars(
+            select(User)
+            .options(selectinload(User.roles))
+        )
+    ).all()
+    
+    semester_balances = (
+        (
+            await session.execute(
+                select(User.id, func.sum(MachineUsage.cost))
+                .join(MachineUsage.user)
+                .where(MachineUsage.semester_id == semester.id)
+                .group_by(User.id)
+            )
+        ).all()
+    )
+
+    return [
+        UserChargeResponse(
+            RIN=user.RIN,
+            first_name=user.first_name,
+            last_name=user.last_name,
+            is_graduating=user.is_graduating,
+            semester_balance=Decimal(
+                next(
+                    (balance.tuple()[1]
+                     for balance in semester_balances
+                     if balance.tuple()[0] == user.id),
+                    0.0
+                )
+                if semester_balances and len(semester_balances) > 0
+                else 0.0
+            ),
+        )
+        for user in users
+    ]
+    

--- a/backend/api/routes/officer_actions.py
+++ b/backend/api/routes/officer_actions.py
@@ -136,10 +136,13 @@ async def get_charge_sheet(
     users = (
         await session.scalars(
             select(User)
+            .join(MachineUsage, MachineUsage.user_id == User.id)
+            .where(MachineUsage.semester_id == semester.id)
             .options(selectinload(User.roles))
+            .distinct()
         )
     ).all()
-    
+
     semester_balances = (
         (
             await session.execute(
@@ -170,4 +173,4 @@ async def get_charge_sheet(
         )
         for user in users
     ]
-    
+

--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 from typing import Annotated, Literal
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import ScalarSelect, and_, func, or_, select
@@ -21,6 +22,35 @@ from core.security import get_password_hash
 
 router = APIRouter()
 
+async def get_semester_balance(
+    session: DBSession,
+    user_id: UUID,
+    semester_id: str
+) -> Decimal:
+    """Calculate the semester balance for a user and semester."""
+    
+    if not semester_id:
+        return Decimal(0)
+    
+    semester_balance = (
+        (
+            await session.scalar(
+                select(func.sum(MachineUsage.cost))
+                .select_from(MachineUsage)
+                .where(
+                    and_(
+                        MachineUsage.user_id == user_id,
+                        MachineUsage.semester_id == semester_id,
+                    )
+                )
+            )
+        )
+        or 0.0
+        if semester_id
+        else 0.0
+    )
+
+    return Decimal(semester_balance)
 
 @router.post("/signup")
 async def register_user(
@@ -75,27 +105,8 @@ async def get_user_by_rcsid(
         )
 
     current_semester_id = await session.scalar(select(State.active_semester_id))
-
     user_permissions = await get_user_permissions(session, user.id)
-
-    semester_balance = (
-        (
-            await session.scalar(
-                select(func.sum(MachineUsage.cost))
-                .select_from(MachineUsage)
-                .where(
-                    and_(
-                        MachineUsage.user_id == user.id,
-                        MachineUsage.semester_id == current_semester_id,
-                    )
-                )
-            )
-        )
-        or 0.0
-        if current_semester_id
-        else 0.0
-    )
-
+    semester_balance = await get_semester_balance(session, user.id, current_semester_id)
     return UserNoHash(
         id=user.id,
         is_rpi_staff=user.is_rpi_staff,
@@ -115,7 +126,7 @@ async def get_user_by_rcsid(
             ""
         ),
         is_graduating=user.is_graduating,
-        semester_balance=Decimal(semester_balance),
+        semester_balance=semester_balance,
     )
 
 
@@ -136,27 +147,8 @@ async def get_user_by_rin(
         raise HTTPException(status_code=404, detail="User with provided RIN not found")
 
     current_semester_id = await session.scalar(select(State.active_semester_id))
-
     user_permissions = await get_user_permissions(session, user.id)
-
-    semester_balance = (
-        (
-            await session.scalar(
-                select(func.sum(MachineUsage.cost))
-                .select_from(MachineUsage)
-                .where(
-                    and_(
-                        MachineUsage.user_id == user.id,
-                        MachineUsage.semester_id == current_semester_id,
-                    )
-                )
-            )
-        )
-        or 0.0
-        if current_semester_id
-        else 0.0
-    )
-
+    semester_balance = await get_semester_balance(session, user.id, current_semester_id)
     return UserNoHash(
         id=user.id,
         is_rpi_staff=user.is_rpi_staff,
@@ -176,7 +168,7 @@ async def get_user_by_rin(
             ""
         ),
         is_graduating=user.is_graduating,
-        semester_balance=Decimal(semester_balance),
+        semester_balance=semester_balance,
     )
 
 

--- a/backend/schemas/responses.py
+++ b/backend/schemas/responses.py
@@ -30,6 +30,14 @@ class BasicUserResponse(BaseResponse):
     last_name: str
 
 
+class UserChargeResponse(BaseResponse):
+    RIN: str
+    first_name: str
+    last_name: str
+    semester_balance: Decimal = Field(max_digits=10, decimal_places=2)
+    is_graduating: bool
+
+
 class UserNoHash(BaseModel):
     id: UUID4
 

--- a/frontend/src/components/MyForge/MyForge.tsx
+++ b/frontend/src/components/MyForge/MyForge.tsx
@@ -17,6 +17,7 @@ const Users = lazy(() => import('./tabs/Users'));
 const Usages = lazy(() => import('./tabs/Usages'));
 const ComingSoon = lazy(() => import( '../Home/ComingSoon'));
 const Semesters = lazy(() => import('./tabs/Semesters'));
+const ChargeSheets = lazy(() => import('./tabs/ChargeSheets'));
 
 
 interface MyForgeProps {
@@ -48,7 +49,7 @@ const MyForge: React.FC = () => {
                         <Route path="resource_slots" element={<ResourceSlots />} />
                         <Route path="users" element={<Users />} />
                         <Route path="semesters" element={<Semesters />} />
-                        <Route path="charge_sheets" element={<ComingSoon />} />
+                        <Route path="charge_sheets" element={<ChargeSheets />} />
                         <Route path="change_config" element={<ComingSoon />} />
                     </Routes>
                 </Suspense>

--- a/frontend/src/components/MyForge/tabs/ChargeSheets.tsx
+++ b/frontend/src/components/MyForge/tabs/ChargeSheets.tsx
@@ -1,0 +1,203 @@
+import React, { useState, useEffect } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Cross2Icon } from '@radix-ui/react-icons';
+import { OmniAPI } from 'src/apis/OmniAPI';
+import { UserPermission } from 'src/enums';
+import Table, { ITEMS_PER_PAGE, TableHead } from '../components/Table';
+import useAuth from '../../Auth/useAuth';
+
+import { UserCharge, Semester } from 'src/interfaces';
+import { SEMESTER_TYPE_MAP } from './Semesters';
+
+type ChargeSheetCsvRow = {
+    rin: string;
+    firstName: string;
+    lastName: string;
+    membershipCharge: string;
+    usagesCharge: string;
+    totalCharge: string;
+};
+
+const ChargeSheets: React.FC = () => {
+    const { user } = useAuth();
+    const canGetCharges = user.permissions.includes(UserPermission.CAN_GET_CHARGES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+
+    const [data, setData] = useState<UserCharge[]>([]);
+    const [currentPage, setCurrentPage] = useState(1);
+    const columns: (keyof UserCharge)[] = ['RIN', 'first_name', 'last_name', 'semester_balance', 'is_graduating'];
+
+    const [semesterId, setSemesterId] = useState<string | null>(null);
+    const [semesters, setSemesters] = useState<Semester[]>([]);
+
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [membershipCharge, setMembershipCharge] = useState<number | ''>('');
+
+    useEffect(() => {
+        Promise.all([
+            OmniAPI.getAll('semesters', { limit: 1000 }),
+            OmniAPI.get('semesters', 'current'),
+        ]).then(([all, current]) => {
+            setSemesters(Array.isArray(all) ? all : []);
+            setSemesterId(current.id);
+        });
+    }, []);
+
+    const fetchPage = (page: number) => {
+        const offset = (page - 1) * ITEMS_PER_PAGE;
+        OmniAPI.getAll('users', { limit: ITEMS_PER_PAGE, offset }).then((res) => {
+            setData(Array.isArray(res) ? res : []);
+            setCurrentPage(page);
+        });
+    };
+
+    useEffect(() => {
+        fetchPage(1);
+    }, [semesterId]);
+
+    const handleSemesterChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        setSemesterId(e.target.value);
+    };
+
+    // CSV CREATION
+    function getSemesterName(semester: Semester | undefined | null): string {
+        if (!semester) return 'Semester';
+        let semTypeStr = '';
+        if (typeof semester.semester_type === 'number') {
+            semTypeStr = SEMESTER_TYPE_MAP[semester.semester_type] ?? String(semester.semester_type);
+        } else {
+            semTypeStr = SEMESTER_TYPE_MAP[Number(semester.semester_type)] ?? String(semester.semester_type);
+        }
+        return `${semTypeStr}_${semester.calendar_year}`;
+    }
+
+    function getRowsByGraduating(charges: UserCharge[], membership: number, isGraduating: boolean): ChargeSheetCsvRow[] {
+        return charges.filter((row) => Boolean(row.is_graduating) === isGraduating).map((row) => {
+            const usages = Number(row.semester_balance ?? 0);
+            const total = membership + usages;
+            return {
+                rin: row.RIN,
+                firstName: row.first_name,
+                lastName: row.last_name,
+                membershipCharge: membership.toFixed(2),
+                usagesCharge: usages.toFixed(2),
+                totalCharge: total.toFixed(2)
+            };
+        });
+    }
+
+    function downloadCSV(rows: ChargeSheetCsvRow[], semesterName: string, graduatingornot: string) {
+        const csvHeader = ['RIN', 'First Name', 'Last Name', 'Membership Charge', 'Usages Charge', 'Total Charge'];
+        const escapeCSV = (field: any) => {
+            const str = String(field ?? '');
+            if (str.includes('"') || str.includes(',') || str.includes('\n') || str.includes('\r')) {
+                return '"' + str.replace(/"/g, '""') + '"';
+            }
+            return str;
+        };
+        const csvRows = rows.map((row) => [
+            row.rin,
+            row.firstName,
+            row.lastName,
+            row.membershipCharge,
+            row.usagesCharge,
+            row.totalCharge
+        ]);
+        const csvContent = [csvHeader, ...csvRows]
+            .map(r => r.map(escapeCSV).join(','))
+            .join('\r\n');
+        const blob = new Blob([csvContent], { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${semesterName}_Forge_Charges_${graduatingornot}.csv`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
+
+    const handleCreateChargeSheet = async () => {
+        if (!semesterId || membershipCharge === '' || isNaN(Number(membershipCharge))) {
+            alert('Please select a semester and enter a valid membership charge.');
+            return;
+        }
+        try {
+            const chargesResponse = await OmniAPI.exec('get_charges', { semester_id: semesterId });
+            const charges: UserCharge[] = Array.isArray(chargesResponse) ? chargesResponse : [];
+            const membership = Number(membershipCharge);
+
+            const graduatingRows = getRowsByGraduating(charges, membership, true);
+            const nongraduatingRows = getRowsByGraduating(charges, membership, false);
+
+            const selectedSemester = semesters.find(s => String(s.id) === String(semesterId));
+            const semesterName = getSemesterName(selectedSemester);
+
+            if (graduatingRows.length > 0) downloadCSV(graduatingRows, semesterName, 'graduating');
+            if (nongraduatingRows.length > 0) downloadCSV(nongraduatingRows, semesterName, 'nongraduating');
+            setDialogOpen(false);
+        } catch (err) {
+            alert('Failed to create charge sheet.');
+        }
+    };
+
+    if (!canGetCharges) return null;
+    return (
+        <div className='tab-column-cover align-center'>
+            <TableHead heading="Charge Sheets" />
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 12, width: '100%',  padding: 30}}>
+                <Dialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
+                    <Dialog.Trigger asChild>
+                        <button type="button" className="Button OfficerBtn">
+                            Create Charge Sheet
+                        </button>
+                    </Dialog.Trigger>
+                    <Dialog.Portal>
+                        <div className='AEdiv'>
+                            <Dialog.Overlay className="DialogOverlay" />
+                            <Dialog.Content className="DialogContent" aria-describedby={undefined} style={{ minWidth: 320 }}>
+                                <Dialog.Close asChild>
+                                    <button className="IconButton" aria-label="Close">
+                                        <Cross2Icon />
+                                    </button>
+                                </Dialog.Close>
+                                <Dialog.Title className="DialogTitle">Create Semester Charge Sheet</Dialog.Title>
+                                <fieldset className="Fieldset">
+                                    <label className="Label" htmlFor="semester-select">Semester:</label>
+                                    <select  id="semester-select" value={semesterId ?? ''} onChange={handleSemesterChange} disabled={semesters.length === 0} style={{ width: '100%' }} >
+                                        {semesters.map((sem) => (
+                                            <option key={sem.id} value={sem.id}>
+                                                {getSemesterName(sem).replace('_', ' ')}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </fieldset>
+                                <fieldset className="Fieldset">
+                                    <label className="Label" htmlFor="membership-charge-input">Semester membership charge:</label>
+                                    <input className="Input" id="membership-charge-input" type="number"  min="0" value={membershipCharge} onChange={e => setMembershipCharge(e.target.value === '' ? '' : Number(e.target.value))} style={{ width: '100%' }}/>
+                                </fieldset>
+                                <div className="dialog-actions" style={{ marginTop: 16 }}>
+                                    <button className="Button SaveBtn" style={{ minWidth: 80 }} onClick={handleCreateChargeSheet}>
+                                        Download
+                                    </button>
+                                </div>
+                            </Dialog.Content>
+                        </div>
+                    </Dialog.Portal>
+                </Dialog.Root>
+            </div>
+
+            <div style={{ color: 'red',  paddingLeft: 32, paddingRight: 32}}>
+                Warning: The data below is a visual of the current semester. Export the csv for the charge sheet.
+            </div>
+            <Table<UserCharge>
+                columns={columns}
+                data={data}
+                currentPage={currentPage}
+                onPageChange={fetchPage}
+                resourceType="users"
+            />
+        </div>
+    );
+};
+
+export default ChargeSheets;

--- a/frontend/src/components/MyForge/tabs/Semesters.tsx
+++ b/frontend/src/components/MyForge/tabs/Semesters.tsx
@@ -10,7 +10,7 @@ import { Cross2Icon, PlusIcon } from '@radix-ui/react-icons';
 import * as Dialog from '@radix-ui/react-dialog';
 import { Semester } from 'src/interfaces';
 
-const SEMESTER_TYPE_MAP: { [key: number]: string } = {
+export const SEMESTER_TYPE_MAP: { [key: number]: string } = {
     0: 'Fall',
     1: 'Spring',
     2: 'Summer',

--- a/frontend/src/interfaces.tsx
+++ b/frontend/src/interfaces.tsx
@@ -33,6 +33,14 @@ export const defaultUser: User = {
     semester_balance: '',
 };
 
+export interface UserCharge {
+    RIN: string;
+    first_name: string;
+    last_name: string;
+    semester_balance: string | number;
+    is_graduating: boolean;
+}
+
 export interface Machine {
     id: string;
     name: string;


### PR DESCRIPTION
Created the charge sheet page and endpoint. 

Endpoint `exec/get_charges`:
- Takes in a semester id
- Only users with at least one usage that semester are returned
- I put this in the officer_actions file because they are the only people who will be using it, but can move it somewhere else if people think that'll make more sense

Charge Sheet page:
- **Table:** I have it displaying the current semester information so somebody can see the general structure of semester charges before they download one. In most cases this will be exported at the end of the current semester anyway. For pagination reasons this is actually pulling from the users page, not the charge sheet endpoint, and so doesnt actually filter for whether they have a usage or not - so that's why I've put a disclaimer that its not accurate
- **Dialog:** The user then selects the semester they want to download a charge sheet for, and can optionally input an additional membership charge that will be added to everyone's total usage costs
- **CSV:** People are separated by whether they are graduating in the current semester or not, so if there exist both people who are and are not graduating, two seperate csv's will be created, but if all people are graduating/or not, only that csv will be created
- **Styling:** Yeah, sorry, it's awful again, but global styling will replace and fix everything soon

Page:
<img width="1709" height="797" alt="image" src="https://github.com/user-attachments/assets/9e59622e-2b14-45a7-a3ef-be08a75cd0b3" />

Dialog:
<img width="1072" height="646" alt="image" src="https://github.com/user-attachments/assets/bb4557f2-1ade-43bd-915e-e16a1eca5646" />

Created CSV "Spring_2024_Forge_Charges_nongraduating.csv":
<img width="571" height="146" alt="image" src="https://github.com/user-attachments/assets/0ccf47fa-cd7f-43fe-8230-8031103de3ed" />
