### PR TITLE
Table column width maximum

### DIFF
--- a/frontend/src/components/MyForge/components/Table.tsx
+++ b/frontend/src/components/MyForge/components/Table.tsx
@@ -125,7 +125,7 @@ function Table<T>(props: TableProps<T>) {
     } else {
         return (
             <div className="table-container">
-                <table>
+                <table className={hasEditOrDelete ? 'has-actions' : undefined}>
                     <thead>
                         <tr>
                             {columns.map((column, index) => (

--- a/frontend/src/components/MyForge/components/Table.tsx
+++ b/frontend/src/components/MyForge/components/Table.tsx
@@ -137,13 +137,17 @@ function Table<T>(props: TableProps<T>) {
                     <tbody>
                         {data.map((row, rowIndex) => (
                             <tr key={rowIndex}>
-                                {columns.map(column => (
-                                    <td key={String(column)}>
-                                        {Array.isArray(row[column])
-                                            ? row[column].join(', ')
-                                            : String(row[column])}
-                                    </td>
-                                ))}
+                                {columns.map(column => {
+                                    const value = Array.isArray(row[column])
+                                        ? row[column].join(', ')
+                                        : String(row[column]);
+
+                                    return (
+                                        <td key={String(column)}>
+                                            <span className="cell-content" title={value}>{value}</span>
+                                        </td>
+                                    );
+                                })}
                                 {hasEditOrDelete && (
                                     <td className="icon">
                                         {canEdit && (

--- a/frontend/src/components/MyForge/styles/TabStyles.scss
+++ b/frontend/src/components/MyForge/styles/TabStyles.scss
@@ -1,6 +1,7 @@
 .tab-container {
   display: flex;
   flex-grow: 1;
+  min-width: 0;
   height: 100%;
   overflow: hidden;
 }
@@ -10,6 +11,7 @@
   flex-direction: column;
   height: 100%;
   width: 100%;
+  min-width: 0;
   padding: 0.25rem 0.5rem;
 }
 

--- a/frontend/src/components/MyForge/styles/Table.scss
+++ b/frontend/src/components/MyForge/styles/Table.scss
@@ -29,6 +29,8 @@
 .table-container {
     margin-top: 20px;
     width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
     overflow-x: auto;
     padding: 0 2rem 0 2rem;    
     max-height: 60vh;
@@ -52,6 +54,10 @@
         padding: 8px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
+        max-width: 220px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     th:has(+ #edit-col) {border-right:none;}
@@ -70,7 +76,16 @@
         padding: 12px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
+        max-width: 220px;
         overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .cell-content {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
         white-space: nowrap;
     }
 

--- a/frontend/src/components/MyForge/styles/Table.scss
+++ b/frontend/src/components/MyForge/styles/Table.scss
@@ -23,12 +23,16 @@
         scale: 1.2;
         background-color: #e9ffe9;
     }
-    h2 { float: left;}
+    h2 { float: left; }
 }
 
 .table-container {
     margin-top: 20px;
+    align-self: stretch;
     width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
     overflow-x: auto;
     padding: 0 2rem 0 2rem;    
     max-height: 60vh;
@@ -37,6 +41,8 @@
 
     table {
         width: 100%;
+        min-width: 100%;
+        table-layout: fixed;
         border-collapse: separate;
         border-spacing: 0;
         border: 1px solid #a7a7a7;
@@ -52,7 +58,6 @@
         padding: 8px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
-        max-width: 20%;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -74,8 +79,17 @@
         padding: 12px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
-        max-width: 20%;
         overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .cell-content {
+        display: block;
+        width: 100%;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
         white-space: nowrap;
     }
 

--- a/frontend/src/components/MyForge/styles/Table.scss
+++ b/frontend/src/components/MyForge/styles/Table.scss
@@ -42,7 +42,7 @@
     table {
         width: 100%;
         min-width: 100%;
-        table-layout: fixed;
+        table-layout: auto;
         border-collapse: separate;
         border-spacing: 0;
         border: 1px solid #a7a7a7;
@@ -58,44 +58,69 @@
         padding: 8px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
+        max-width: min(32vw, 26rem);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
     }
 
-    th:has(+ #edit-col) {border-right:none;}
-    
     th:last-of-type {
         border-right: none;
         border-radius: 0 0.5rem 0 0;
         min-width: 3rem;
     }
 
-    
-    td:has(+ .icon) {border-right:none;}
-
     td {
         color: #333333;
         padding: 12px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
+        max-width: min(32vw, 26rem);
         overflow: hidden;
-        text-overflow: ellipsis;
         white-space: nowrap;
+    }
+
+    table.has-actions th:nth-last-child(2),
+    table.has-actions td:nth-last-child(2) {
+        border-right: none;
     }
 
     .cell-content {
         display: block;
         width: 100%;
         min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
+        overflow-x: auto;
+        overflow-y: hidden;
+        text-overflow: clip;
         white-space: nowrap;
+        scrollbar-width: thin;
+        scrollbar-color: #9a9a9a #e8e8e8;
     }
 
-    td:last-of-type {
+    .cell-content::-webkit-scrollbar {
+        height: 6px;
+    }
+
+    .cell-content::-webkit-scrollbar-thumb {
+        background-color: #9a9a9a;
+        border-radius: 999px;
+    }
+
+    .cell-content::-webkit-scrollbar-track {
+        background-color: #e8e8e8;
+        border-radius: 999px;
+    }
+
+    td.icon {
+        width: 5.5rem;
+        min-width: 5.5rem;
+        max-width: 5.5rem;
         border-right: none;
-        white-space: normal;
+        white-space: nowrap;
+        text-align: center;
+        vertical-align: middle;
+        padding-left: 8px;
+        padding-right: 24px;
         .edit,.trash { opacity: 0; }
     }
     
@@ -124,22 +149,22 @@
 }
 
 #edit-col {
-    width: 10%;
+    width: 5.5rem;
+    min-width: 5.5rem;
+    max-width: 5.5rem;
     text-align: center;
 }
 
 .icon {
     text-align: center;
-    display: flex;
-    flex-direction: row;
 }
 
 .icon * {
     transition-duration: .15s;
-    display: block;
+    display: inline-block;
     width: 20pt;
-    height: inherit;
-    padding-right: 5px;
+    height: 20pt;
+    margin: 0 2px;
     cursor: pointer;
     color: inherit;
 }

--- a/frontend/src/components/MyForge/styles/Table.scss
+++ b/frontend/src/components/MyForge/styles/Table.scss
@@ -29,8 +29,6 @@
 .table-container {
     margin-top: 20px;
     width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
     overflow-x: auto;
     padding: 0 2rem 0 2rem;    
     max-height: 60vh;
@@ -54,7 +52,7 @@
         padding: 8px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
-        max-width: 220px;
+        max-width: 20%;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -76,16 +74,8 @@
         padding: 12px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
-        max-width: 220px;
+        max-width: 20%;
         overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
-
-    .cell-content {
-        display: block;
-        overflow: hidden;
-        text-overflow: ellipsis;
         white-space: nowrap;
     }
 

--- a/frontend/src/components/MyForge/styles/UserMenu.scss
+++ b/frontend/src/components/MyForge/styles/UserMenu.scss
@@ -54,6 +54,9 @@
     display: flex;
     flex-direction: column;
     width: 18vw;
+    flex: 0 0 18vw;
+    min-width: 220px;
+    flex-shrink: 0;
     height: 100%;
     background-color: um.$white-background;
     color: um.$text-gray;


### PR DESCRIPTION
Previously, long strings in cells of the table would just make a crazy long table, but now it cuts off gracefully with an ellipses, if you click edit you can still see all the details of that object. If its not editable like usages or users then yeahhhh thats bad but someday some UI/UX person can make these tables flexible and allow the users to change the width of the table columns or something? If reviewers think this is enough of an issue to not merge this PR in, we can come up with a different solution

EDIT: new solution was indeed decided upon, see comment below

<img width="1511" height="645" alt="image" src="https://github.com/user-attachments/assets/95230d72-8891-4d58-a534-4aa2ae45e3bb" />
