### PR TITLE
Adding roles and role assignment pages

### DIFF
--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -12,6 +12,7 @@ from .routes import (
     public,
     resource_slots,
     resources,
+    roles,
     semesters,
     users,
     use_a_machine,
@@ -27,6 +28,7 @@ api_router.include_router(officer_actions.router, tags=["officer_actions"])
 api_router.include_router(public.router, tags=["public"])
 api_router.include_router(resource_slots.router, tags=["resource_slots"])
 api_router.include_router(resources.router, tags=["resources"])
+api_router.include_router(roles.router, tags=["roles"])
 api_router.include_router(semesters.router, tags=["semesters"])
 api_router.include_router(users.router, tags=["users"])
 api_router.include_router(use_a_machine.router, tags=["use_a_machine"])

--- a/backend/api/routes/roles.py
+++ b/backend/api/routes/roles.py
@@ -1,0 +1,252 @@
+""" Role endpoints. """
+
+from typing import Annotated, Literal
+from uuid import UUID
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select, and_
+from sqlalchemy.orm import InstrumentedAttribute
+
+from models.role import Role, UserRoleAssociation
+from models.audit_log import AuditLog
+from schemas.enums import Permissions, LogType
+from schemas.responses import CreateResponse, AuditLogModel, RoleInfo, RoleDetails
+from schemas.requests import RoleCreateRequest, RoleEditRequest
+from ..deps import DBSession, PermittedUserChecker
+from models.user import User
+
+router = APIRouter()
+
+
+@router.post("/roles/new")
+async def create_role(
+    request: RoleCreateRequest,
+    session: DBSession,
+    current_user: Annotated[
+        User, Depends(PermittedUserChecker({Permissions.CAN_CREATE_ROLES}))
+    ],
+):
+    """Create a new role with the provided properties."""
+
+    existing_role = await session.scalar(
+        select(Role).where(Role.name == request.name)
+    )
+    if existing_role:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A role with that name already exists",
+        )
+    
+    valid_permissions = [perm.value for perm in Permissions]
+    permissions = sorted([perm for perm in request.permissions if perm in valid_permissions])
+    inverse_permissions = sorted([perm for perm in request.inverse_permissions if perm in valid_permissions])
+    if len(permissions) != len(request.permissions):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="One or more permissions are invalid",
+        )
+    if len(inverse_permissions) != len(request.inverse_permissions):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="One or more inverse permissions are invalid",
+        )
+
+    new_role = Role(
+        name=request.name,
+        permissions=permissions,
+        inverse_permissions=inverse_permissions,
+        display_role=request.display_role,
+        role_icon_name=None,
+        priority=request.priority,
+    )
+    session.add(new_role)
+    await session.commit()
+    await session.refresh(new_role)
+
+    audit_log = AuditLog(
+        type=LogType.ROLE_CREATED,
+        content={
+            "role_id": str(new_role.id),
+            "user_rcsid": current_user.RCSID,
+            "props": request.model_dump(mode="json"),
+        },
+    )
+    session.add(audit_log)
+    await session.commit()
+
+    return CreateResponse(id=new_role.id)
+
+
+@router.get("/roles/{role_id}")
+async def get_role(
+    role_id: UUID,
+    session: DBSession,
+    current_user: Annotated[
+        User, Depends(PermittedUserChecker({Permissions.CAN_SEE_ROLES}))
+    ],
+):
+    """Fetch the role with the provided ID."""
+    
+    role = await session.scalar(select(Role).where(Role.id == role_id))
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Role with provided ID not found",
+        )
+    audit_logs = (
+        await session.scalars(
+            select(AuditLog)
+            .where(
+                and_(
+                    AuditLog.content.has_key("role_id"),
+                    AuditLog.content["role_id"].astext == str(role_id),
+                )
+            )
+            .order_by(AuditLog.time_created.desc())
+        )
+    ).all()
+
+    return RoleDetails(
+        audit_logs=[AuditLogModel.model_validate(log) for log in audit_logs],
+        **role.__dict__,
+    )
+
+
+@router.get("/roles")
+async def get_all_roles(
+    session: DBSession,
+    current_user: Annotated[
+        User, Depends(PermittedUserChecker({Permissions.CAN_SEE_ROLES}))
+    ],
+    limit: int = 20,
+    offset: int = 0,
+    order_by: Literal[
+        "name",
+        "priority",
+    ] = "name",
+    descending: bool = False,
+):
+    """Fetch all roles."""
+
+    attr_key_map: dict[str, InstrumentedAttribute] = {
+        "name": Role.name,
+        "priority": Role.priority,
+    }
+    order_determinant = attr_key_map[order_by]
+    if descending:
+        order_determinant = order_determinant.desc()
+
+    roles = (
+        await session.scalars(
+            select(Role)
+            .order_by(order_determinant)
+            .offset(offset)
+            .fetch(limit)
+        )
+    ).all()
+    
+    return [
+        RoleInfo(
+            **role.__dict__
+        )
+        for role in roles
+    ]
+
+
+@router.post("/roles/{role_id}")
+async def edit_role(
+    role_id: UUID,
+    request: RoleEditRequest,
+    session: DBSession,
+    current_user: Annotated[
+        User, Depends(PermittedUserChecker({Permissions.CAN_EDIT_ROLES}))
+    ],
+):
+    """Update the role with the provided ID."""
+    
+    role = await session.scalar(select(Role).where(Role.id == role_id))
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Role with provided ID not found",
+        )
+
+    valid_permissions = [perm.value for perm in Permissions]
+    permissions = sorted([perm for perm in request.permissions if perm in valid_permissions])
+    inverse_permissions = sorted([perm for perm in request.inverse_permissions if perm in valid_permissions])
+    if len(permissions) != len(request.permissions):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="One or more permissions are invalid",
+        )
+    if len(inverse_permissions) != len(request.inverse_permissions):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="One or more inverse permissions are invalid",
+        )
+
+    differences = {
+        "name": request.name if role.name != request.name else None,
+        "permissions": permissions if role.permissions != permissions else None,
+        "inverse_permissions": inverse_permissions if role.inverse_permissions != inverse_permissions else None,
+        "display_role": request.display_role if role.display_role != request.display_role else None,
+        "role_icon_name": None if role.role_icon_name is not None else None,
+        "priority": request.priority if role.priority != request.priority else None,
+    }
+
+    role.name = request.name
+    role.permissions = permissions
+    role.inverse_permissions = inverse_permissions
+    role.display_role = request.display_role
+    role.role_icon_name = None
+    role.priority = request.priority
+
+    audit_log = AuditLog(
+        type=LogType.ROLE_EDITED,
+        content={
+            "role_id": str(role.id),
+            "user_rcsid": current_user.RCSID,
+            "changed_values": differences,
+        },
+    )
+    session.add(audit_log)
+
+    await session.commit()
+
+
+@router.delete("/roles/{role_id}")
+async def delete_role(
+    role_id: UUID,
+    session: DBSession,
+    current_user: Annotated[
+        User, Depends(PermittedUserChecker({Permissions.CAN_DELETE_ROLES}))
+    ],
+):
+    """Delete the role with the provided ID."""
+
+    role = await session.scalar(select(Role).where(Role.id == role_id))
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Role with provided ID not found",
+        )
+
+    users = (
+        await session.scalars(
+            select(UserRoleAssociation).where(UserRoleAssociation.role_id == role.id)
+        )
+    ).all()
+    if len(users):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot delete a role that is assigned to users",
+        )
+
+    await session.delete(role)
+
+    audit_log = AuditLog(
+        type=LogType.ROLE_DELETED,
+        content={"role_id": str(role.id), "user_rcsid": current_user.RCSID},
+    )
+    session.add(audit_log)
+
+    await session.commit()

--- a/backend/api/routes/roles.py
+++ b/backend/api/routes/roles.py
@@ -10,7 +10,7 @@ from models.role import Role, UserRoleAssociation
 from models.audit_log import AuditLog
 from schemas.enums import Permissions, LogType
 from schemas.responses import CreateResponse, AuditLogModel, RoleInfo, RoleDetails
-from schemas.requests import RoleCreateRequest, RoleEditRequest
+from schemas.requests import RoleCreateRequest, RoleEditRequest, UserAddRoleRequest
 from ..deps import DBSession, PermittedUserChecker
 from models.user import User
 
@@ -150,6 +150,52 @@ async def get_all_roles(
         )
         for role in roles
     ]
+
+
+@router.post("/roles/user")
+async def change_user_role(
+    request: UserAddRoleRequest,
+    session: DBSession,
+    current_user: Annotated[
+        User, Depends(PermittedUserChecker({Permissions.CAN_CHANGE_USER_ROLES}))
+    ],
+):
+    """Assign or unassign a role for a user."""
+
+    user = await session.scalar(select(User).where(User.id == request.user_id))
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User with provided ID not found",
+        )
+
+    role = await session.scalar(select(Role).where(Role.id == request.role_id))
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Role with provided ID not found",
+        )
+
+    association = await session.scalar(
+        select(UserRoleAssociation).where(
+            and_(
+                UserRoleAssociation.user_id == request.user_id,
+                UserRoleAssociation.role_id == request.role_id,
+            )
+        )
+    )
+
+    if request.should_have_role:
+        if not association:
+            session.add(
+                UserRoleAssociation(user_id=request.user_id, role_id=request.role_id)
+            )
+            await session.commit()
+        return
+
+    if association:
+        await session.delete(association)
+        await session.commit()
 
 
 @router.post("/roles/{role_id}")

--- a/backend/api/routes/roles.py
+++ b/backend/api/routes/roles.py
@@ -4,9 +4,9 @@ from typing import Annotated, Literal
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select, and_
-from sqlalchemy.orm import InstrumentedAttribute
+from sqlalchemy.orm import InstrumentedAttribute, selectinload
 
-from models.role import Role, UserRoleAssociation
+from models.role import Role
 from models.audit_log import AuditLog
 from schemas.enums import Permissions, LogType
 from schemas.responses import CreateResponse, AuditLogModel, RoleInfo, RoleDetails
@@ -152,50 +152,6 @@ async def get_all_roles(
     ]
 
 
-@router.post("/roles/user")
-async def change_user_role(
-    request: UserAddRoleRequest,
-    session: DBSession,
-    current_user: Annotated[
-        User, Depends(PermittedUserChecker({Permissions.CAN_CHANGE_USER_ROLES}))
-    ],
-):
-    """Assign or unassign a role for a user."""
-
-    user = await session.scalar(select(User).where(User.id == request.user_id))
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User with provided ID not found",
-        )
-
-    role = await session.scalar(select(Role).where(Role.id == request.role_id))
-    if not role:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Role with provided ID not found",
-        )
-
-    association = await session.scalar(
-        select(UserRoleAssociation).where(
-            and_(
-                UserRoleAssociation.user_id == request.user_id,
-                UserRoleAssociation.role_id == request.role_id,
-            )
-        )
-    )
-
-    if request.should_have_role:
-        if not association:
-            session.add(
-                UserRoleAssociation(user_id=request.user_id, role_id=request.role_id)
-            )
-            await session.commit()
-        return
-
-    if association:
-        await session.delete(association)
-        await session.commit()
 
 
 @router.post("/roles/{role_id}")
@@ -269,19 +225,16 @@ async def delete_role(
 ):
     """Delete the role with the provided ID."""
 
-    role = await session.scalar(select(Role).where(Role.id == role_id))
+    role = await session.scalar(
+        select(Role).where(Role.id == role_id).options(selectinload(Role.users))
+    )
     if not role:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Role with provided ID not found",
         )
 
-    users = (
-        await session.scalars(
-            select(UserRoleAssociation).where(UserRoleAssociation.role_id == role.id)
-        )
-    ).all()
-    if len(users):
+    if role.users:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Cannot delete a role that is assigned to users",

--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -284,6 +284,84 @@ async def get_all_users(
     ]
 
 
+@router.get("/users/role/{role_id}", tags=["users"])
+async def get_users_by_role(
+    role_id: UUID,
+    session: DBSession,
+    current_user: Annotated[
+        User, Depends(PermittedUserChecker({Permissions.CAN_SEE_USERS}))
+    ],
+) -> list[UserNoHash]:
+    """Get all users that have a given role."""
+
+    current_semester_id = await session.scalar(select(State.active_semester_id))
+
+    users = (
+        await session.scalars(
+            select(User)
+            .join(User.roles)
+            .where(Role.id == role_id)
+            .options(selectinload(User.roles))
+        )
+    ).all()
+
+    semester_balances = (
+        (
+            await session.execute(
+                select(User.id, func.sum(MachineUsage.cost))
+                .join(MachineUsage.user)
+                .where(
+                    and_(
+                        MachineUsage.semester_id == current_semester_id,
+                        User.id.in_([u.id for u in users])
+                    )
+                )
+                .group_by(User.id)
+            )
+        ).all()
+        if current_semester_id
+        else None
+    )
+
+    user_permissions = {
+        user.id: await get_user_permissions(session, user.id)
+        for user in users
+    }
+
+    return [
+        UserNoHash(
+            id=user.id,
+            is_rpi_staff=user.is_rpi_staff,
+            RCSID=user.RCSID,
+            RIN=user.RIN,
+            first_name=user.first_name,
+            last_name=user.last_name,
+            major=user.major,
+            gender_identity=user.gender_identity,
+            pronouns=user.pronouns,
+            permissions=user_permissions[user.id],
+            display_role=next((
+                    role.name 
+                    for role in user.roles 
+                    if role.display_role
+                ), 
+                ""
+            ),
+            is_graduating=user.is_graduating,
+            semester_balance=Decimal(
+                next(
+                    (balance.tuple()[1]
+                     for balance in semester_balances
+                     if balance.tuple()[0] == user.id),
+                    0.0
+                )
+                if semester_balances and len(semester_balances) > 0
+                else 0.0
+            ),
+        )
+        for user in users
+    ]
+
 # GET ALL USERS
 
 # EDIT USER PREFERENCES

--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 from typing import Annotated, Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import ScalarSelect, and_, func, or_, select
 from sqlalchemy.orm import selectinload, InstrumentedAttribute
 
@@ -15,7 +15,7 @@ from models.machine_usage import MachineUsage
 from models.role import Role
 from models.user import User
 from schemas.enums import Permissions
-from schemas.requests import UserCreateRequest
+from schemas.requests import UserCreateRequest, UserAddRoleRequest
 from schemas.responses import BasicUserResponse, UserNoHash
 
 from core.security import get_password_hash
@@ -366,6 +366,45 @@ async def get_users_by_role(
         )
         for user in users
     ]
+
+
+@router.post("/users/role")
+async def change_user_role(
+    request: UserAddRoleRequest,
+    session: DBSession,
+    current_user: Annotated[
+        User, Depends(PermittedUserChecker({Permissions.CAN_CHANGE_USER_ROLES}))
+    ],
+):
+    """Assign or unassign a role for a user."""
+
+    user = await session.scalar(
+        select(User).where(User.id == request.user_id).options(selectinload(User.roles))
+    )
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User with provided ID not found",
+        )
+
+    role = await session.scalar(select(Role).where(Role.id == request.role_id))
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Role with provided ID not found",
+        )
+
+    if request.should_have_role:
+        if role not in user.roles:
+            user.roles.append(role)
+            session.add(user)
+            await session.commit()
+        return
+
+    if role in user.roles:
+        user.roles.remove(role)
+        session.add(user)
+        await session.commit()
 
 # GET ALL USERS
 

--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -291,6 +291,8 @@ async def get_users_by_role(
     current_user: Annotated[
         User, Depends(PermittedUserChecker({Permissions.CAN_SEE_USERS}))
     ],
+    limit: int = 20,
+    offset: int = 0,
 ) -> list[UserNoHash]:
     """Get all users that have a given role."""
 
@@ -302,6 +304,9 @@ async def get_users_by_role(
             .join(User.roles)
             .where(Role.id == role_id)
             .options(selectinload(User.roles))
+            .order_by(User.RCSID)
+            .limit(limit)
+            .offset(offset)
         )
     ).all()
 

--- a/backend/schemas/requests.py
+++ b/backend/schemas/requests.py
@@ -254,6 +254,7 @@ class RoleDeleteRequest(BaseRequest):
 class UserAddRoleRequest(BaseRequest):
     user_id: UUID4
     role_id: UUID4
+    should_have_role: bool
 
 
 class OrgCreateRequest(BaseRequest):

--- a/backend/schemas/responses.py
+++ b/backend/schemas/responses.py
@@ -136,6 +136,19 @@ class ResourceSlotInfo(BaseModel):
 class ResourceSlotDetails(ResourceSlotInfo):
     audit_logs: list[AuditLogModel]
 
+    
+class RoleInfo(BaseModel):
+    id: UUID4
+    name: str
+    permissions: list[str]
+    inverse_permissions: list[str]
+    display_role: bool
+    priority: int
+
+
+class RoleDetails(RoleInfo):
+    audit_logs: list[AuditLogModel]
+
 
 class MachineTypeInfo(BaseModel):
     id: UUID4

--- a/frontend/src/components/Auth/AuthContext.tsx
+++ b/frontend/src/components/Auth/AuthContext.tsx
@@ -10,6 +10,7 @@ import * as AlertDialog from "@radix-ui/react-alert-dialog";
 import { userState } from "src/GlobalAtoms";
 import { AuthAPI } from "src/apis/AuthAPI";
 import { User } from "src/interfaces";
+import { UserPermission } from 'src/enums';
 
 import "./Auth.css"
 
@@ -21,6 +22,7 @@ interface AuthContextType {
     setAuth: (value: boolean) => void;
     setUser: (value: User) => void;
     logout: () => void;
+    hasPermission: (permission: UserPermission) => boolean;
 }
 
 const LOGOUT_TIME_LIMIT = 5;    // minutes user can stay logged in
@@ -226,6 +228,14 @@ const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
         logout();
     }, [logoutTimerId, logout]);
 
+    
+    // -------------------------
+    //   PERMISSIONS HELPER FUNCTION
+    // -------------------------
+    const hasPermission = (permission: UserPermission) => (
+        user.permissions.includes(permission) || user.permissions.includes(UserPermission.IS_SUPERUSER)
+    );
+
     return (
         <AuthContext.Provider
             value={{
@@ -235,6 +245,7 @@ const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
                 setAuth,
                 setUser,
                 logout,
+                hasPermission,
             }}
         >
             {/*

--- a/frontend/src/components/MyForge/MyForge.tsx
+++ b/frontend/src/components/MyForge/MyForge.tsx
@@ -19,6 +19,7 @@ const ComingSoon = lazy(() => import( '../Home/ComingSoon'));
 const Semesters = lazy(() => import('./tabs/Semesters'));
 const ChargeSheets = lazy(() => import('./tabs/ChargeSheets'));
 const Roles = lazy(() => import('./tabs/Roles'));
+const UserRoles = lazy(() => import('./tabs/UserRoles'));
 
 
 interface MyForgeProps {
@@ -50,6 +51,7 @@ const MyForge: React.FC = () => {
                         <Route path="resource_slots" element={<ResourceSlots />} />
                         <Route path="users" element={<Users />} />
                         <Route path="roles" element={<Roles />} />
+                        <Route path="user_roles" element={<UserRoles />} />
                         <Route path="semesters" element={<Semesters />} />
                         <Route path="charge_sheets" element={<ChargeSheets />} />
                     </Routes>

--- a/frontend/src/components/MyForge/MyForge.tsx
+++ b/frontend/src/components/MyForge/MyForge.tsx
@@ -18,6 +18,7 @@ const Usages = lazy(() => import('./tabs/Usages'));
 const ComingSoon = lazy(() => import( '../Home/ComingSoon'));
 const Semesters = lazy(() => import('./tabs/Semesters'));
 const ChargeSheets = lazy(() => import('./tabs/ChargeSheets'));
+const Roles = lazy(() => import('./tabs/Roles'));
 
 
 interface MyForgeProps {
@@ -48,9 +49,9 @@ const MyForge: React.FC = () => {
                         <Route path="resources" element={<Resources />} />
                         <Route path="resource_slots" element={<ResourceSlots />} />
                         <Route path="users" element={<Users />} />
+                        <Route path="roles" element={<Roles />} />
                         <Route path="semesters" element={<Semesters />} />
                         <Route path="charge_sheets" element={<ChargeSheets />} />
-                        <Route path="change_config" element={<ComingSoon />} />
                     </Routes>
                 </Suspense>
             </div>

--- a/frontend/src/components/MyForge/components/Table.tsx
+++ b/frontend/src/components/MyForge/components/Table.tsx
@@ -125,7 +125,7 @@ function Table<T>(props: TableProps<T>) {
     } else {
         return (
             <div className="table-container">
-                <table>
+                <table className={hasEditOrDelete ? 'has-actions' : undefined}>
                     <thead>
                         <tr>
                             {columns.map((column, index) => (

--- a/frontend/src/components/MyForge/components/Table.tsx
+++ b/frontend/src/components/MyForge/components/Table.tsx
@@ -137,13 +137,17 @@ function Table<T>(props: TableProps<T>) {
                     <tbody>
                         {data.map((row, rowIndex) => (
                             <tr key={rowIndex}>
-                                {columns.map(column => (
-                                    <td key={String(column)}>
-                                        {Array.isArray(row[column])
-                                            ? row[column].join(', ')
-                                            : String(row[column])}
-                                    </td>
-                                ))}
+                                {columns.map(column => {
+                                    const value = Array.isArray(row[column])
+                                        ? row[column].join(', ')
+                                        : String(row[column]);
+
+                                    return (
+                                        <td key={String(column)}>
+                                            <span className="cell-content" title={value}>{value}</span>
+                                        </td>
+                                    );
+                                })}
                                 {hasEditOrDelete && (
                                     <td className="icon">
                                         {canEdit && (

--- a/frontend/src/components/MyForge/components/Table.tsx
+++ b/frontend/src/components/MyForge/components/Table.tsx
@@ -8,6 +8,7 @@ interface TableProps<T> {
     columns: (keyof T)[];
     data: T[];
     canEdit?: boolean;
+    canDelete?: boolean;
     onEdit?: (activeItem: T) => void;
     onDelete?: (index_local: number, index_real:number) => void;
     currentPage?: number;
@@ -54,14 +55,15 @@ export function TableHead<T>(props: TableHeadProps<T>) {
 }
 
 function Table<T>(props: TableProps<T>) {
-    const { columns, data, onDelete, onEdit, canEdit } = props;
+    const { columns, data, onDelete, onEdit, canEdit, canDelete } = props;
     const {
         currentPage: currentPageProp,
         onPageChange,
         resourceType
     } = props;
 
-    const hasEditOrDelete = !!(canEdit || onDelete);
+    const hasDelete = !!(canDelete && onDelete);
+    const hasEditOrDelete = !!(canEdit || hasDelete);
 
     const currentPage = currentPageProp ?? 1;
     const [hasNext, setHasNext] = useState(false);
@@ -156,7 +158,7 @@ function Table<T>(props: TableProps<T>) {
                                                 onClick={() => onEdit?.(row)}
                                             />
                                         )}
-                                        {onDelete && (
+                                        {hasDelete && (
                                             <TrashIcon
                                                 className="trash"
                                                 onClick={() => onDelete(rowIndex, rowIndex)}

--- a/frontend/src/components/MyForge/components/UserMenu.tsx
+++ b/frontend/src/components/MyForge/components/UserMenu.tsx
@@ -67,7 +67,7 @@ const UserMenu: React.FC = () => {
                         <li><Link to='/myforge/users' className='btn'>Users</Link></li>
                     )}
                 </ul>
-                { (hasPermission(UserPermission.CAN_SEE_SEMESTERS) || hasPermission(UserPermission.CAN_GET_CHARGES)) && (
+                { (hasPermission(UserPermission.CAN_SEE_SEMESTERS) || hasPermission(UserPermission.CAN_GET_CHARGES) || hasPermission(UserPermission.CAN_SEE_ROLES)) && (
                     <hr className='divider' />
                 )}
                 <ul className='user-options eboard'>
@@ -77,8 +77,8 @@ const UserMenu: React.FC = () => {
                     { hasPermission(UserPermission.CAN_GET_CHARGES) && (
                         <li><Link to='/myforge/charge_sheets' className='btn'>Charge Sheets</Link></li>
                     )}
-                    { hasPermission(UserPermission.IS_SUPERUSER) && (
-                        <li><Link to='/myforge/change_config' className='btn'>Change Configuration</Link></li>
+                    { hasPermission(UserPermission.CAN_SEE_ROLES) && (
+                        <li><Link to='/myforge/roles' className='btn'>Roles</Link></li>
                     )}
                 </ul>
             </nav>

--- a/frontend/src/components/MyForge/components/UserMenu.tsx
+++ b/frontend/src/components/MyForge/components/UserMenu.tsx
@@ -8,9 +8,7 @@ import '../styles/UserMenu.scss';
 
 const UserMenu: React.FC = () => {
 
-    const { user } = useAuth();
-
-    const hasPermission = (permission: UserPermission) => user.permissions.includes(permission) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { user, hasPermission } = useAuth();
 
     return (
     <div className="sidebar">

--- a/frontend/src/components/MyForge/components/UserMenu.tsx
+++ b/frontend/src/components/MyForge/components/UserMenu.tsx
@@ -67,18 +67,21 @@ const UserMenu: React.FC = () => {
                         <li><Link to='/myforge/users' className='btn'>Users</Link></li>
                     )}
                 </ul>
-                { (hasPermission(UserPermission.CAN_SEE_SEMESTERS) || hasPermission(UserPermission.CAN_GET_CHARGES) || hasPermission(UserPermission.CAN_SEE_ROLES)) && (
+                { (hasPermission(UserPermission.CAN_SEE_SEMESTERS) || hasPermission(UserPermission.CAN_GET_CHARGES) || hasPermission(UserPermission.CAN_SEE_ROLES) || hasPermission(UserPermission.CAN_CHANGE_USER_ROLES)) && (
                     <hr className='divider' />
                 )}
                 <ul className='user-options eboard'>
+                    { hasPermission(UserPermission.CAN_CHANGE_USER_ROLES) && (
+                        <li><Link to='/myforge/user_roles' className='btn'>User Roles</Link></li>
+                    )}
+                    { hasPermission(UserPermission.CAN_SEE_ROLES) && (
+                        <li><Link to='/myforge/roles' className='btn'>Roles</Link></li>
+                    )}
                     { hasPermission(UserPermission.CAN_SEE_SEMESTERS) && (
                         <li><Link to='/myforge/semesters' className='btn'>Semesters</Link></li>
                     )}
                     { hasPermission(UserPermission.CAN_GET_CHARGES) && (
                         <li><Link to='/myforge/charge_sheets' className='btn'>Charge Sheets</Link></li>
-                    )}
-                    { hasPermission(UserPermission.CAN_SEE_ROLES) && (
-                        <li><Link to='/myforge/roles' className='btn'>Roles</Link></li>
                     )}
                 </ul>
             </nav>

--- a/frontend/src/components/MyForge/styles/TabStyles.scss
+++ b/frontend/src/components/MyForge/styles/TabStyles.scss
@@ -1,6 +1,7 @@
 .tab-container {
   display: flex;
   flex-grow: 1;
+  min-width: 0;
   height: 100%;
   overflow: hidden;
 }
@@ -10,6 +11,7 @@
   flex-direction: column;
   height: 100%;
   width: 100%;
+  min-width: 0;
   padding: 0.25rem 0.5rem;
 }
 

--- a/frontend/src/components/MyForge/styles/Table.scss
+++ b/frontend/src/components/MyForge/styles/Table.scss
@@ -29,6 +29,8 @@
 .table-container {
     margin-top: 20px;
     width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
     overflow-x: auto;
     padding: 0 2rem 0 2rem;    
     max-height: 60vh;
@@ -52,6 +54,10 @@
         padding: 8px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
+        max-width: 220px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     th:has(+ #edit-col) {border-right:none;}
@@ -70,7 +76,16 @@
         padding: 12px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
+        max-width: 220px;
         overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .cell-content {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
         white-space: nowrap;
     }
 

--- a/frontend/src/components/MyForge/styles/Table.scss
+++ b/frontend/src/components/MyForge/styles/Table.scss
@@ -23,12 +23,16 @@
         scale: 1.2;
         background-color: #e9ffe9;
     }
-    h2 { float: left;}
+    h2 { float: left; }
 }
 
 .table-container {
     margin-top: 20px;
+    align-self: stretch;
     width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
     overflow-x: auto;
     padding: 0 2rem 0 2rem;    
     max-height: 60vh;
@@ -37,6 +41,8 @@
 
     table {
         width: 100%;
+        min-width: 100%;
+        table-layout: fixed;
         border-collapse: separate;
         border-spacing: 0;
         border: 1px solid #a7a7a7;
@@ -52,7 +58,6 @@
         padding: 8px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
-        max-width: 20%;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -74,8 +79,17 @@
         padding: 12px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
-        max-width: 20%;
         overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .cell-content {
+        display: block;
+        width: 100%;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
         white-space: nowrap;
     }
 

--- a/frontend/src/components/MyForge/styles/Table.scss
+++ b/frontend/src/components/MyForge/styles/Table.scss
@@ -42,7 +42,7 @@
     table {
         width: 100%;
         min-width: 100%;
-        table-layout: fixed;
+        table-layout: auto;
         border-collapse: separate;
         border-spacing: 0;
         border: 1px solid #a7a7a7;
@@ -58,44 +58,69 @@
         padding: 8px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
+        max-width: min(32vw, 26rem);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
     }
 
-    th:has(+ #edit-col) {border-right:none;}
-    
     th:last-of-type {
         border-right: none;
         border-radius: 0 0.5rem 0 0;
         min-width: 3rem;
     }
 
-    
-    td:has(+ .icon) {border-right:none;}
-
     td {
         color: #333333;
         padding: 12px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
+        max-width: min(32vw, 26rem);
         overflow: hidden;
-        text-overflow: ellipsis;
         white-space: nowrap;
+    }
+
+    table.has-actions th:nth-last-child(2),
+    table.has-actions td:nth-last-child(2) {
+        border-right: none;
     }
 
     .cell-content {
         display: block;
         width: 100%;
         min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
+        overflow-x: auto;
+        overflow-y: hidden;
+        text-overflow: clip;
         white-space: nowrap;
+        scrollbar-width: thin;
+        scrollbar-color: #9a9a9a #e8e8e8;
     }
 
-    td:last-of-type {
+    .cell-content::-webkit-scrollbar {
+        height: 6px;
+    }
+
+    .cell-content::-webkit-scrollbar-thumb {
+        background-color: #9a9a9a;
+        border-radius: 999px;
+    }
+
+    .cell-content::-webkit-scrollbar-track {
+        background-color: #e8e8e8;
+        border-radius: 999px;
+    }
+
+    td.icon {
+        width: 5.5rem;
+        min-width: 5.5rem;
+        max-width: 5.5rem;
         border-right: none;
-        white-space: normal;
+        white-space: nowrap;
+        text-align: center;
+        vertical-align: middle;
+        padding-left: 8px;
+        padding-right: 24px;
         .edit,.trash { opacity: 0; }
     }
     
@@ -124,22 +149,22 @@
 }
 
 #edit-col {
-    width: 10%;
+    width: 5.5rem;
+    min-width: 5.5rem;
+    max-width: 5.5rem;
     text-align: center;
 }
 
 .icon {
     text-align: center;
-    display: flex;
-    flex-direction: row;
 }
 
 .icon * {
     transition-duration: .15s;
-    display: block;
+    display: inline-block;
     width: 20pt;
-    height: inherit;
-    padding-right: 5px;
+    height: 20pt;
+    margin: 0 2px;
     cursor: pointer;
     color: inherit;
 }

--- a/frontend/src/components/MyForge/styles/Table.scss
+++ b/frontend/src/components/MyForge/styles/Table.scss
@@ -29,8 +29,6 @@
 .table-container {
     margin-top: 20px;
     width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
     overflow-x: auto;
     padding: 0 2rem 0 2rem;    
     max-height: 60vh;
@@ -54,7 +52,7 @@
         padding: 8px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
-        max-width: 220px;
+        max-width: 20%;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -76,16 +74,8 @@
         padding: 12px;
         border-bottom: 1px solid #a0a0a0;
         border-right: 1px solid #a0a0a0;
-        max-width: 220px;
+        max-width: 20%;
         overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
-
-    .cell-content {
-        display: block;
-        overflow: hidden;
-        text-overflow: ellipsis;
         white-space: nowrap;
     }
 

--- a/frontend/src/components/MyForge/styles/Table.scss
+++ b/frontend/src/components/MyForge/styles/Table.scss
@@ -371,10 +371,9 @@
     }
 
     .SaveBtn {
-        position: absolute;
-        margin: 1rem;
-        right: 0;
-        bottom: 0;
+        position: static;
+        align-self: flex-end;
+        margin-top: 1rem;
     }
 
     .IconButton {

--- a/frontend/src/components/MyForge/styles/UserMenu.scss
+++ b/frontend/src/components/MyForge/styles/UserMenu.scss
@@ -54,6 +54,9 @@
     display: flex;
     flex-direction: column;
     width: 18vw;
+    flex: 0 0 18vw;
+    min-width: 220px;
+    flex-shrink: 0;
     height: 100%;
     background-color: um.$white-background;
     color: um.$text-gray;

--- a/frontend/src/components/MyForge/tabs/ChargeSheets.tsx
+++ b/frontend/src/components/MyForge/tabs/ChargeSheets.tsx
@@ -19,8 +19,8 @@ type ChargeSheetCsvRow = {
 };
 
 const ChargeSheets: React.FC = () => {
-    const { user } = useAuth();
-    const canGetCharges = user.permissions.includes(UserPermission.CAN_GET_CHARGES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canGetCharges = hasPermission(UserPermission.CAN_GET_CHARGES);
 
     const [data, setData] = useState<UserCharge[]>([]);
     const [currentPage, setCurrentPage] = useState(1);

--- a/frontend/src/components/MyForge/tabs/MachineGroups.tsx
+++ b/frontend/src/components/MyForge/tabs/MachineGroups.tsx
@@ -19,9 +19,9 @@ interface aemenuprops {
 }
 
 const aemenu = (props: aemenuprops): [ReactNode, (state: boolean, mach: MachineGroup | null) => void] => {
-    const { user } = useAuth();
-    const canCreate = user.permissions.includes(UserPermission.CAN_CREATE_MACHINE_GROUPS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_MACHINE_GROUPS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canCreate = hasPermission(UserPermission.CAN_CREATE_MACHINE_GROUPS);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_MACHINE_GROUPS);
 
     let { isDialogOpen, setIsDialogOpen, machineGroup, setMachineGroup, refresh} = props;
 
@@ -151,9 +151,9 @@ const aemenu = (props: aemenuprops): [ReactNode, (state: boolean, mach: MachineG
 };
 
 const MachineGroups: React.FC = () => {
-    const { user } = useAuth();
-    const canDelete = user.permissions.includes(UserPermission.CAN_DELETE_MACHINE_GROUPS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_MACHINE_GROUPS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canDelete = hasPermission(UserPermission.CAN_DELETE_MACHINE_GROUPS);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_MACHINE_GROUPS);
 
     const [data, setData] = React.useState<MachineGroup[]>([]);
     const columns: (keyof MachineGroup)[] = data.length > 0 ? (Object.keys(data[0]) as (keyof MachineGroup)[]).filter((key) => key !== 'id') : [];

--- a/frontend/src/components/MyForge/tabs/MachineGroups.tsx
+++ b/frontend/src/components/MyForge/tabs/MachineGroups.tsx
@@ -211,6 +211,7 @@ const MachineGroups: React.FC = () => {
                 onDelete={onDelete}
                 onEdit={(e) => setOpen(true, e)}
                 canEdit={canEdit}
+                canDelete={canDelete}
                 currentPage={currentPage}
                 onPageChange={fetchPage}
                 resourceType="machinegroups"

--- a/frontend/src/components/MyForge/tabs/MachineTypes.tsx
+++ b/frontend/src/components/MyForge/tabs/MachineTypes.tsx
@@ -207,6 +207,7 @@ const MachineTypes: React.FC = () => {
                 onDelete={onDelete}
                 onEdit={(e) => setOpen(true, e)}
                 canEdit={canEdit}
+                canDelete={canDelete}
                 currentPage={currentPage}
                 onPageChange={(p) => fetchPage(p)}
                 resourceType={"machinetypes"}

--- a/frontend/src/components/MyForge/tabs/MachineTypes.tsx
+++ b/frontend/src/components/MyForge/tabs/MachineTypes.tsx
@@ -23,9 +23,9 @@ interface aemenuprops {
 const aemenu = (props: aemenuprops): [ReactNode, (state: boolean, mach: MachineType | null) => void] => {
     let { isDialogOpen, setIsDialogOpen, machineType, setMachineType, refresh} = props;
 
-    const { user } = useAuth();
-    const canCreate = user.permissions.includes(UserPermission.CAN_CREATE_MACHINE_TYPES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_MACHINE_TYPES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canCreate = hasPermission(UserPermission.CAN_CREATE_MACHINE_TYPES);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_MACHINE_TYPES);
         
     const [name, setName] = useState("");
     const [resourceSlots, setResourceSlots] = useState<ResourceSlot[]>([]);
@@ -160,9 +160,9 @@ const aemenu = (props: aemenuprops): [ReactNode, (state: boolean, mach: MachineT
 };
 
 const MachineTypes: React.FC = () => {
-    const { user } = useAuth();
-    const canDelete = user.permissions.includes(UserPermission.CAN_DELETE_MACHINE_TYPES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_MACHINE_TYPES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canDelete = hasPermission(UserPermission.CAN_DELETE_MACHINE_TYPES);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_MACHINE_TYPES);
 
     const [data, setData] = React.useState<MachineType[]>([]);
     const columns: (keyof MachineType)[] = data.length > 0 ? (Object.keys(data[0]) as (keyof MachineType)[]).filter( (key) => !key.includes('_id') && key !== 'id' ) : [];

--- a/frontend/src/components/MyForge/tabs/Machines.tsx
+++ b/frontend/src/components/MyForge/tabs/Machines.tsx
@@ -218,6 +218,7 @@ const Machines: React.FC = () => {
                 onDelete={onDelete}
                 onEdit={onEdit}
                 canEdit={canEdit}
+                canDelete={canDelete}
                 currentPage={currentPage}
                 onPageChange={fetchPage}
                 resourceType="machines"

--- a/frontend/src/components/MyForge/tabs/Machines.tsx
+++ b/frontend/src/components/MyForge/tabs/Machines.tsx
@@ -18,9 +18,9 @@ interface aemenuprops {
 }
 
 const AEMenu: React.FC<aemenuprops> = ({ isDialogOpen, setIsDialogOpen, machine, setMachine, refresh,}) => {
-    const { user } = useAuth();
-    const canCreate = user.permissions.includes(UserPermission.CAN_CREATE_MACHINES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_MACHINES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canCreate = hasPermission(UserPermission.CAN_CREATE_MACHINES);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_MACHINES);
     
     const [name, setName] = useState("");
 
@@ -155,9 +155,9 @@ const AEMenu: React.FC<aemenuprops> = ({ isDialogOpen, setIsDialogOpen, machine,
 
 
 const Machines: React.FC = () => {
-    const { user } = useAuth();
-    const canDelete = user.permissions.includes(UserPermission.CAN_DELETE_MACHINES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_MACHINES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canDelete = hasPermission(UserPermission.CAN_DELETE_MACHINES);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_MACHINES);
 
     const [data, setData] = React.useState<Machine[]>([]);
     const columns: (keyof Machine)[] = data.length > 0 ? (Object.keys(data[0]) as (keyof Machine)[]).filter((key) => !key.includes('_id') && key !== 'id') : [];

--- a/frontend/src/components/MyForge/tabs/ResourceSlots.tsx
+++ b/frontend/src/components/MyForge/tabs/ResourceSlots.tsx
@@ -23,9 +23,9 @@ interface aemenuprops {
 const aemenu = (props: aemenuprops): [ReactNode, (state: boolean, rslot: ResourceSlot | null) => void] => {
     let { isDialogOpen, setIsDialogOpen, resourceSlot, setResourceSlot, refresh} = props;
     
-    const { user } = useAuth();
-    const canCreate = user.permissions.includes(UserPermission.CAN_CREATE_RESOURCE_SLOTS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_RESOURCE_SLOTS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canCreate = hasPermission(UserPermission.CAN_CREATE_RESOURCE_SLOTS);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_RESOURCE_SLOTS);
 
     const [name, setName] = useState("");
     const [resources, setResources] = useState<Resource[]>([]);
@@ -187,9 +187,9 @@ const aemenu = (props: aemenuprops): [ReactNode, (state: boolean, rslot: Resourc
 }
 
 const ResourceSlots: React.FC = () => {
-    const { user } = useAuth();
-    const canDelete = user.permissions.includes(UserPermission.CAN_DELETE_RESOURCE_SLOTS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_RESOURCE_SLOTS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canDelete = hasPermission(UserPermission.CAN_DELETE_RESOURCE_SLOTS);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_RESOURCE_SLOTS);
 
     const [data, setData] = React.useState<ResourceSlot[]>([]);
     const columns: (keyof ResourceSlot)[] = data.length > 0 ? (Object.keys(data[0]) as (keyof ResourceSlot)[]).filter((key) => !key.includes('db_name') && !(key == 'name') && !key.includes('id') && !key.includes('valid_resource_ids')) : [];

--- a/frontend/src/components/MyForge/tabs/ResourceSlots.tsx
+++ b/frontend/src/components/MyForge/tabs/ResourceSlots.tsx
@@ -234,6 +234,7 @@ const ResourceSlots: React.FC = () => {
                 onDelete={onDelete}
                 onEdit={(e) => setOpen(true, e)}
                 canEdit={canEdit}
+                canDelete={canDelete}
                 currentPage={currentPage}
                 onPageChange={fetchPage}
                 resourceType="resourceslots"

--- a/frontend/src/components/MyForge/tabs/Resources.tsx
+++ b/frontend/src/components/MyForge/tabs/Resources.tsx
@@ -23,9 +23,9 @@ interface aemenuprops {
 const aemenu = (props: aemenuprops): [ReactNode, (state: boolean, res: Resource | null) => void] =>  {
     let { isDialogOpen, setIsDialogOpen, resource, setResource, refresh} = props;
     
-    const { user } = useAuth();
-    const canCreate = user.permissions.includes(UserPermission.CAN_CREATE_RESOURCES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_RESOURCES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canCreate = hasPermission(UserPermission.CAN_CREATE_RESOURCES);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_RESOURCES);
 
     const [name, setName] = useState("");
     const [brand, setBrand] = useState("");
@@ -130,9 +130,9 @@ const aemenu = (props: aemenuprops): [ReactNode, (state: boolean, res: Resource 
 
 
 const Resources: React.FC = () => {
-    const { user } = useAuth();
-    const canDelete = user.permissions.includes(UserPermission.CAN_DELETE_RESOURCES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_RESOURCES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canDelete = hasPermission(UserPermission.CAN_DELETE_RESOURCES);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_RESOURCES);
 
     const [data, setData] = React.useState<Resource[]>([]);
     const columns: (keyof Resource)[] = data.length > 0 ? (Object.keys(data[0]) as (keyof Resource)[]).filter((key) => !key.includes('_id') && key !== 'id') : [];

--- a/frontend/src/components/MyForge/tabs/Resources.tsx
+++ b/frontend/src/components/MyForge/tabs/Resources.tsx
@@ -177,6 +177,7 @@ const Resources: React.FC = () => {
                 onDelete={onDelete}
                 onEdit={(e) => { setOpen(true, e);}}
                 canEdit={canEdit}
+                canDelete={canDelete}
                 currentPage={currentPage}
                 onPageChange={fetchPage}
                 resourceType="resources"

--- a/frontend/src/components/MyForge/tabs/Roles.tsx
+++ b/frontend/src/components/MyForge/tabs/Roles.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { OmniAPI } from 'src/apis/OmniAPI';
+import Table, { ITEMS_PER_PAGE, TableHead } from '../components/Table';
+import { UserPermission } from 'src/enums';
+import useAuth from '../../Auth/useAuth';
+import '../styles/TabStyles.scss';
+
+const Roles: React.FC = () => {
+
+    const { user } = useAuth();
+    const canSeeRoles = user.permissions.includes(UserPermission.CAN_SEE_ROLES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+
+    const [data, setData] = React.useState<Role[]>([]);
+    const columns: (keyof Role)[] = data.length > 0 ? (Object.keys(data[0]) as (keyof Role)[]).filter((key) => key !== 'id') : [];
+    const [currentPage, setCurrentPage] = useState(1);
+
+    const fetchPage = (page: number) => {
+        const offset = (page - 1) * ITEMS_PER_PAGE;
+        OmniAPI.getAll('roles', { limit: ITEMS_PER_PAGE, offset }).then((res) => {
+            setData(Array.isArray(res) ? (res as Role[]) : []);
+            setCurrentPage(page);
+        });
+    };
+
+    React.useEffect(() => {
+        fetchPage(1);
+    }, []);
+
+    if (!canSeeRoles) return null;
+    return (
+        <div className='tab-column-cover align-center'>
+            <TableHead heading="Roles" />
+            <Table<Role>
+                columns={columns}
+                data={data}
+                currentPage={currentPage}
+                onPageChange={fetchPage}
+                resourceType="roles"
+            />
+        </div>
+    );
+};
+
+export default Roles;

--- a/frontend/src/components/MyForge/tabs/Roles.tsx
+++ b/frontend/src/components/MyForge/tabs/Roles.tsx
@@ -180,9 +180,9 @@ const aemenu = (props: AEMenuProps): [ReactNode, (state: boolean, role: Role | n
                                         alignItems: 'center',
                                     }}
                                 >
-                                    <label className='checkbox-label' style={{ textAlign: 'center', margin: 0 }}>Y</label>
-                                    <label className='checkbox-label' style={{ textAlign: 'center', margin: 0 }}>N</label>
-                                    <label className='checkbox-label' style={{ margin: 0 }}>Permission</label>
+                                    <div className='checkbox-label' style={{ textAlign: 'center'}}>Y</div>
+                                    <div className='checkbox-label' style={{ textAlign: 'center'}}>N</div>
+                                    <div className='checkbox-label'> Permission</div>
 
                                     {allPermissions.map((permission) => (
                                         <React.Fragment key={`perm-${permission}`}>
@@ -200,9 +200,9 @@ const aemenu = (props: AEMenuProps): [ReactNode, (state: boolean, role: Role | n
                                                 onChange={() => toggleInversePermission(permission)}
                                                 style={{ margin: 0, justifySelf: 'center' }}
                                             />
-                                            <label className='checkbox-label' style={{ margin: 0, overflowWrap: 'anywhere' }}>
+                                            <div className='checkbox-label' style={{ overflowWrap: 'anywhere' }}>
                                                 {permission}
-                                            </label>
+                                            </div>
                                         </React.Fragment>
                                     ))}
                                 </div>

--- a/frontend/src/components/MyForge/tabs/Roles.tsx
+++ b/frontend/src/components/MyForge/tabs/Roles.tsx
@@ -1,14 +1,230 @@
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { OmniAPI } from 'src/apis/OmniAPI';
-import Table, { ITEMS_PER_PAGE, TableHead } from '../components/Table';
+import Table, { DeleteItem, ITEMS_PER_PAGE, TableHead } from '../components/Table';
+import { Role } from 'src/interfaces';
 import { UserPermission } from 'src/enums';
 import useAuth from '../../Auth/useAuth';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Cross2Icon, PlusIcon } from '@radix-ui/react-icons';
+// @ts-ignore temporary: stylesheet module typing not configured in this project path yet
 import '../styles/TabStyles.scss';
+
+interface AEMenuProps {
+    isDialogOpen: boolean;
+    setIsDialogOpen: (open: boolean) => void;
+    role: Role | null;
+    setRole: (role: Role | null) => void;
+    refresh: () => void;
+}
+
+const aemenu = (props: AEMenuProps): [ReactNode, (state: boolean, role: Role | null) => void] => {
+    const { isDialogOpen, setIsDialogOpen, role, setRole, refresh } = props;
+
+    const { user } = useAuth();
+    const canCreate = user.permissions.includes(UserPermission.CAN_CREATE_ROLES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_ROLES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+
+    const [name, setName] = useState('');
+    const [priority, setPriority] = useState(0);
+    const [displayRole, setDisplayRole] = useState(false);
+    const [permissions, setPermissions] = useState<UserPermission[]>([]);
+    const [inversePermissions, setInversePermissions] = useState<UserPermission[]>([]);
+
+    const allPermissions = Object.values(UserPermission);
+
+    const setOpenExtra = (state: boolean, activeRole: Role | null) => {
+        setRole(activeRole);
+        if (activeRole) {
+            setName(activeRole.name);
+            setPriority(activeRole.priority);
+            setDisplayRole(activeRole.display_role);
+            setPermissions((activeRole.permissions ?? []) as UserPermission[]);
+            setInversePermissions((activeRole.inverse_permissions ?? []) as UserPermission[]);
+        } else {
+            setName('');
+            setPriority(0);
+            setDisplayRole(false);
+            setPermissions([]);
+            setInversePermissions([]);
+        }
+        if (isDialogOpen !== state) {
+            setIsDialogOpen(state);
+        }
+    };
+
+    const togglePermission = (perm: UserPermission) => {
+        const hasPermission = permissions.includes(perm);
+        if (hasPermission) {
+            setPermissions((prev) => prev.filter((p) => p !== perm));
+            return;
+        }
+
+        setPermissions((prev) => [...prev, perm]);
+        setInversePermissions((prev) => prev.filter((p) => p !== perm));
+    };
+
+    const toggleInversePermission = (perm: UserPermission) => {
+        const hasInversePermission = inversePermissions.includes(perm);
+        if (hasInversePermission) {
+            setInversePermissions((prev) => prev.filter((p) => p !== perm));
+            return;
+        }
+
+        setInversePermissions((prev) => [...prev, perm]);
+        setPermissions((prev) => prev.filter((p) => p !== perm));
+    };
+
+    const create = () => {
+        if (!canCreate) {
+            alert('You do not have the permissions to create roles');
+            return;
+        }
+        if (!name.trim()) {
+            alert('Role name is required');
+            return;
+        }
+
+        OmniAPI.create('roles', {
+            name: name.trim(),
+            permissions: permissions,
+            inverse_permissions: inversePermissions,
+            display_role: displayRole,
+            priority: priority,
+        }).then(() => {
+            refresh();
+            setOpenExtra(false, null);
+        });
+    };
+
+    const edit = () => {
+        if (!canEdit) {
+            alert('You do not have the permissions to edit roles');
+            return;
+        }
+        if (!role) return;
+        if (!name.trim()) {
+            alert('Role name is required');
+            return;
+        }
+        
+
+        OmniAPI.edit('roles', role.id, {
+            role_id: role.id,
+            name: name.trim(),
+            permissions: permissions,
+            inverse_permissions: inversePermissions,
+            display_role: displayRole,
+            priority: priority,
+        }).then(() => {
+            refresh();
+            setOpenExtra(false, null);
+        });
+    };
+
+    if (!canCreate && !canEdit) return [null, () => {}];
+    return [(
+        <Dialog.Root open={isDialogOpen} onOpenChange={(open) => setOpenExtra(open, role)}>
+            {canCreate && (
+                <button className="addbtn" onClick={() => setOpenExtra(true, null)}>
+                    <PlusIcon />
+                </button>
+            )}
+            {(canCreate || canEdit) && (
+                <Dialog.Portal>
+                    <div className='AEdiv'>
+                        <Dialog.Overlay className="DialogOverlay" />
+                        <Dialog.Content className="DialogContent" aria-describedby={undefined}>
+                            <Dialog.Close asChild>
+                                <button className="IconButton" aria-label="Close">
+                                    <Cross2Icon />
+                                </button>
+                            </Dialog.Close>
+                            <Dialog.Title className="DialogTitle">{role == null ? 'Adding' : 'Editing'} Role</Dialog.Title>
+
+                            <fieldset className="Fieldset">
+                                <label className="Label" htmlFor="role-name">Name</label>
+                                <input
+                                    className="Input"
+                                    id="role-name"
+                                    value={name}
+                                    onChange={(e) => setName(e.target.value)}
+                                    maxLength={100}
+                                />
+
+                                <label className="Label" htmlFor="role-priority">Priority</label>
+                                <input
+                                    className="Input"
+                                    id="role-priority"
+                                    type="number"
+                                    value={priority}
+                                    onChange={(e) => setPriority(Number(e.target.value) || 0)}
+                                />
+
+                                <label className="Label" htmlFor="display-role">Display role?</label>
+                                <input
+                                    className="styled-checkbox"
+                                    id="display-role"
+                                    type="checkbox"
+                                    checked={displayRole}
+                                    onChange={(e) => setDisplayRole(e.target.checked)}
+                                />
+
+                                <label className="Label" htmlFor="permissions"><div>Permission Settings</div></label>
+                                <div
+                                    id="permissions"
+                                    style={{
+                                        display: 'grid',
+                                        gridTemplateColumns: '32px 32px minmax(0, 1fr)',
+                                        columnGap: '10px',
+                                        rowGap: '8px',
+                                        alignItems: 'center',
+                                    }}
+                                >
+                                    <label className='checkbox-label' style={{ textAlign: 'center', margin: 0 }}>Y</label>
+                                    <label className='checkbox-label' style={{ textAlign: 'center', margin: 0 }}>N</label>
+                                    <label className='checkbox-label' style={{ margin: 0 }}>Permission</label>
+
+                                    {allPermissions.map((permission) => (
+                                        <React.Fragment key={`perm-${permission}`}>
+                                            <input
+                                                className='styled-checkbox'
+                                                type="checkbox"
+                                                checked={permissions.includes(permission)}
+                                                onChange={() => togglePermission(permission)}
+                                                style={{ margin: 0, justifySelf: 'center' }}
+                                            />
+                                            <input
+                                                className='styled-checkbox'
+                                                type="checkbox"
+                                                checked={inversePermissions.includes(permission)}
+                                                onChange={() => toggleInversePermission(permission)}
+                                                style={{ margin: 0, justifySelf: 'center' }}
+                                            />
+                                            <label className='checkbox-label' style={{ margin: 0, overflowWrap: 'anywhere' }}>
+                                                {permission}
+                                            </label>
+                                        </React.Fragment>
+                                    ))}
+                                </div>
+                            </fieldset>
+
+                            <Dialog.Close asChild>
+                                <button className="Button SaveBtn" onClick={role == null ? create : edit}>Save</button>
+                            </Dialog.Close>
+                        </Dialog.Content>
+                    </div>
+                </Dialog.Portal>
+            )}
+        </Dialog.Root>
+    ), setOpenExtra];
+};
 
 const Roles: React.FC = () => {
 
     const { user } = useAuth();
     const canSeeRoles = user.permissions.includes(UserPermission.CAN_SEE_ROLES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const canDelete = user.permissions.includes(UserPermission.CAN_DELETE_ROLES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_ROLES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
 
     const [data, setData] = React.useState<Role[]>([]);
     const columns: (keyof Role)[] = data.length > 0 ? (Object.keys(data[0]) as (keyof Role)[]).filter((key) => key !== 'id') : [];
@@ -16,7 +232,7 @@ const Roles: React.FC = () => {
 
     const fetchPage = (page: number) => {
         const offset = (page - 1) * ITEMS_PER_PAGE;
-        OmniAPI.getAll('roles', { limit: ITEMS_PER_PAGE, offset }).then((res) => {
+        OmniAPI.getAll('roles', { limit: ITEMS_PER_PAGE, offset, order_by: 'priority' }).then((res) => {
             setData(Array.isArray(res) ? (res as Role[]) : []);
             setCurrentPage(page);
         });
@@ -26,13 +242,38 @@ const Roles: React.FC = () => {
         fetchPage(1);
     }, []);
 
+    const refreshPage = () => fetchPage(currentPage);
+
+    const onDelete = (index_local: number, index_real: number) => {
+        if (!canDelete) {
+            alert('You do not have the permissions to delete roles');
+            return;
+        }
+        DeleteItem('roles', data[index_real], refreshPage);
+    };
+
+    const [role, setRole] = useState<Role | null>(null);
+    const [isDialogOpen, setIsDialogOpen] = useState(false);
+    const [ae, setOpen] = aemenu({ isDialogOpen, setIsDialogOpen, role, setRole, refresh: refreshPage });
+
+    const onEdit = (activeRole: Role) => {
+        if (!canEdit) {
+            alert('You do not have the permissions to edit roles');
+            return;
+        }
+        setOpen(true, activeRole);
+    };
+
     if (!canSeeRoles) return null;
     return (
         <div className='tab-column-cover align-center'>
-            <TableHead heading="Roles" />
+            <TableHead heading="Roles" type="roles" aemenu={ae} />
             <Table<Role>
                 columns={columns}
                 data={data}
+                onDelete={onDelete}
+                onEdit={onEdit}
+                canEdit={canEdit}
                 currentPage={currentPage}
                 onPageChange={fetchPage}
                 resourceType="roles"

--- a/frontend/src/components/MyForge/tabs/Roles.tsx
+++ b/frontend/src/components/MyForge/tabs/Roles.tsx
@@ -274,6 +274,7 @@ const Roles: React.FC = () => {
                 onDelete={onDelete}
                 onEdit={onEdit}
                 canEdit={canEdit}
+                canDelete={canDelete}
                 currentPage={currentPage}
                 onPageChange={fetchPage}
                 resourceType="roles"

--- a/frontend/src/components/MyForge/tabs/Roles.tsx
+++ b/frontend/src/components/MyForge/tabs/Roles.tsx
@@ -6,7 +6,7 @@ import { UserPermission } from 'src/enums';
 import useAuth from '../../Auth/useAuth';
 import * as Dialog from '@radix-ui/react-dialog';
 import { Cross2Icon, PlusIcon } from '@radix-ui/react-icons';
-// @ts-ignore temporary: stylesheet module typing not configured in this project path yet
+// @ts-ignore temporary: stylesheet module typing not configured in this project path yet // this'll get fixed soon
 import '../styles/TabStyles.scss';
 
 interface AEMenuProps {

--- a/frontend/src/components/MyForge/tabs/Roles.tsx
+++ b/frontend/src/components/MyForge/tabs/Roles.tsx
@@ -20,9 +20,9 @@ interface AEMenuProps {
 const aemenu = (props: AEMenuProps): [ReactNode, (state: boolean, role: Role | null) => void] => {
     const { isDialogOpen, setIsDialogOpen, role, setRole, refresh } = props;
 
-    const { user } = useAuth();
-    const canCreate = user.permissions.includes(UserPermission.CAN_CREATE_ROLES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_ROLES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canCreate = hasPermission(UserPermission.CAN_CREATE_ROLES);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_ROLES);
 
     const [name, setName] = useState('');
     const [priority, setPriority] = useState(0);
@@ -53,8 +53,8 @@ const aemenu = (props: AEMenuProps): [ReactNode, (state: boolean, role: Role | n
     };
 
     const togglePermission = (perm: UserPermission) => {
-        const hasPermission = permissions.includes(perm);
-        if (hasPermission) {
+        const includesPermission = permissions.includes(perm);
+        if (includesPermission) {
             setPermissions((prev) => prev.filter((p) => p !== perm));
             return;
         }
@@ -221,10 +221,10 @@ const aemenu = (props: AEMenuProps): [ReactNode, (state: boolean, role: Role | n
 
 const Roles: React.FC = () => {
 
-    const { user } = useAuth();
-    const canSeeRoles = user.permissions.includes(UserPermission.CAN_SEE_ROLES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canDelete = user.permissions.includes(UserPermission.CAN_DELETE_ROLES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_ROLES) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canSeeRoles = hasPermission(UserPermission.CAN_SEE_ROLES);
+    const canDelete = hasPermission(UserPermission.CAN_DELETE_ROLES);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_ROLES);
 
     const [data, setData] = React.useState<Role[]>([]);
     const columns: (keyof Role)[] = data.length > 0 ? (Object.keys(data[0]) as (keyof Role)[]).filter((key) => key !== 'id') : [];

--- a/frontend/src/components/MyForge/tabs/Semesters.tsx
+++ b/frontend/src/components/MyForge/tabs/Semesters.tsx
@@ -263,6 +263,7 @@ const Semesters: React.FC = () => {
                 onDelete={onDelete}
                 onEdit={(e) => { setOpen(true, e); }}
                 canEdit={canEdit}
+                canDelete={canDelete}
                 currentPage={currentPage}
                 onPageChange={fetchPage}
                 resourceType="semesters"

--- a/frontend/src/components/MyForge/tabs/Semesters.tsx
+++ b/frontend/src/components/MyForge/tabs/Semesters.tsx
@@ -32,9 +32,9 @@ interface aemenuprops {
 const aemenu = (props: aemenuprops): [ReactNode, (state: boolean, sem: Semester | null) => void] => {
     let { isDialogOpen, setIsDialogOpen, semester, setSemester, refresh } = props;
 
-    const { user } = useAuth();
-    const canCreate = user.permissions.includes(UserPermission.CAN_CREATE_SEMESTERS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_SEMESTERS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canCreate = hasPermission(UserPermission.CAN_CREATE_SEMESTERS);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_SEMESTERS);
 
     const [semesterType, setSemesterType] = useState<number>(0);
     const [calendarYear, setCalendarYear] = useState<number>(0);
@@ -126,10 +126,10 @@ const aemenu = (props: aemenuprops): [ReactNode, (state: boolean, sem: Semester 
 };
 
 const Semesters: React.FC = () => {
-    const { user } = useAuth();
-    const canDelete = user.permissions.includes(UserPermission.CAN_DELETE_SEMESTERS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canEdit = user.permissions.includes(UserPermission.CAN_EDIT_SEMESTERS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
-    const canOfficer = user.permissions.includes(UserPermission.CAN_CHANGE_SEMESTER) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canDelete = hasPermission(UserPermission.CAN_DELETE_SEMESTERS);
+    const canEdit = hasPermission(UserPermission.CAN_EDIT_SEMESTERS);
+    const canOfficer = hasPermission(UserPermission.CAN_CHANGE_SEMESTER);
 
     const [data, setData] = useState<Semester[]>([]);
     const [currentSemester, setCurrentSemester] = useState<Semester | null>(null);

--- a/frontend/src/components/MyForge/tabs/UserRoles.tsx
+++ b/frontend/src/components/MyForge/tabs/UserRoles.tsx
@@ -110,7 +110,7 @@ const UserRoles: React.FC = () => {
         const activeUser = assignedUsers[index_real];
         if (!activeUser || !selectedRoleId) return;
 
-        OmniAPI.edit('roles', 'user', {
+        OmniAPI.edit('users', 'role', {
             user_id: activeUser.id,
             role_id: selectedRoleId,
             should_have_role: false,
@@ -128,7 +128,7 @@ const UserRoles: React.FC = () => {
         }
         if (!selectedRoleId) return;
 
-        OmniAPI.edit('roles', 'user', {
+        OmniAPI.edit('users', 'role', {
             user_id: activeUser.id,
             role_id: selectedRoleId,
             should_have_role: true,

--- a/frontend/src/components/MyForge/tabs/UserRoles.tsx
+++ b/frontend/src/components/MyForge/tabs/UserRoles.tsx
@@ -32,6 +32,7 @@ const UserRoles: React.FC = () => {
     const [addUsersPageData, setAddUsersPageData] = useState<RoleUserRow[]>([]);
     const [addUsersHasMore, setAddUsersHasMore] = useState(false);
     const [userSearchQuery, setUserSearchQuery] = useState('');
+    const selectedRoleName = allRoles.find((activeRole) => activeRole.id === selectedRoleId)?.name ?? 'Selected Role';
 
     const fetchRoles = async () => {
         try {
@@ -246,7 +247,7 @@ const UserRoles: React.FC = () => {
                                     <Cross2Icon />
                                 </button>
                             </Dialog.Close>
-                            <Dialog.Title className='DialogTitle'>Add Users to Role</Dialog.Title>
+                            <Dialog.Title className='DialogTitle'>Assign Users the {selectedRoleName} Role</Dialog.Title>
                             <fieldset className='Fieldset'>
                                 <label className='Label' htmlFor='user-search'>Search</label>
                                 <input
@@ -258,7 +259,7 @@ const UserRoles: React.FC = () => {
                                         setAddUsersPageIndex(1);
                                         fetchAddUsersPage(1);
                                     }}
-                                    placeholder='Search by first name, last name, or RCSID'
+                                    placeholder='Search by name or RCSID'
                                 />
                                 <label className='Label'>Users</label>
                                 <div className='table-container' style={{ marginTop: '0.25rem', padding: 0, maxHeight: '30vh' }}>

--- a/frontend/src/components/MyForge/tabs/UserRoles.tsx
+++ b/frontend/src/components/MyForge/tabs/UserRoles.tsx
@@ -258,7 +258,7 @@ const UserRoles: React.FC = () => {
                                     }}
                                     placeholder='Search by name or RCSID'
                                 />
-                                <label className='Label'>Users</label>
+                                <div className='Label'>Users</div>
                                 <div className='table-container' style={{ marginTop: '0.25rem', padding: 0, maxHeight: '30vh' }}>
                                     <table>
                                         <thead>

--- a/frontend/src/components/MyForge/tabs/UserRoles.tsx
+++ b/frontend/src/components/MyForge/tabs/UserRoles.tsx
@@ -1,0 +1,324 @@
+import React, { useEffect, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { ArrowLeftIcon, ArrowRightIcon, Cross2Icon, PlusIcon } from '@radix-ui/react-icons';
+
+import { OmniAPI } from 'src/apis/OmniAPI';
+import { Role, User } from 'src/interfaces';
+import { UserPermission } from 'src/enums';
+import useAuth from '../../Auth/useAuth';
+import Table, { ITEMS_PER_PAGE, TableHead } from '../components/Table';
+
+import '../styles/TabStyles.scss';
+
+type RoleUserRow = Pick<User, 'id' | 'first_name' | 'last_name' | 'RCSID'>;
+
+const UserRoles: React.FC = () => {
+    const { user } = useAuth();
+
+    const hasPermission = (permission: UserPermission) => (
+        user.permissions.includes(permission) || user.permissions.includes(UserPermission.IS_SUPERUSER)
+    );
+
+    const canSeeRoles = hasPermission(UserPermission.CAN_SEE_ROLES);
+    const canSeeUsers = hasPermission(UserPermission.CAN_SEE_USERS);
+    const canChangeUserRoles = hasPermission(UserPermission.CAN_CHANGE_USER_ROLES);
+
+    const [allRoles, setAllRoles] = useState<Role[]>([]);
+    const [selectedRoleId, setSelectedRoleId] = useState('');
+    const [assignedUsers, setAssignedUsers] = useState<RoleUserRow[]>([]);
+
+    const [showAddUsersPanel, setShowAddUsersPanel] = useState(false);
+    const [addUsersPageIndex, setAddUsersPageIndex] = useState(1);
+    const [addUsersPageData, setAddUsersPageData] = useState<RoleUserRow[]>([]);
+    const [addUsersHasMore, setAddUsersHasMore] = useState(false);
+    const [userSearchQuery, setUserSearchQuery] = useState('');
+
+    const fetchRoles = async () => {
+        try {
+            // shouldnt need pagination, since there wont be 1000+ roles
+            const res = await OmniAPI.getAll('roles', { limit: 1000, offset: 0, order_by: 'priority' });
+            const fetchedRoles = Array.isArray(res) ? (res as Role[]) : [];
+            setAllRoles(fetchedRoles);
+            if (!selectedRoleId && fetchedRoles.length > 0) {
+                setSelectedRoleId(fetchedRoles[0].id);
+            }
+        } catch {
+            setAllRoles([]);
+        }
+    };
+
+    const fetchUsersForSelectedRole = () => {
+        if (!selectedRoleId) {
+            setAssignedUsers([]);
+            return;
+        }
+
+        OmniAPI.get('users/role', selectedRoleId)
+            .then((res) => {
+                const users = Array.isArray(res) ? (res as User[]) : [];
+                setAssignedUsers(users.map((activeUser) => ({
+                    id: activeUser.id,
+                    first_name: activeUser.first_name,
+                    last_name: activeUser.last_name,
+                    RCSID: activeUser.RCSID,
+                })));
+            })
+            .catch(() => setAssignedUsers([]));
+    };
+
+    const fetchAddUsersPage = (pageIndex: number) => {
+        if (!canSeeUsers) return;
+        
+        const offset = (pageIndex - 1) * ITEMS_PER_PAGE;
+        OmniAPI.getAll('users', { limit: ITEMS_PER_PAGE + 1, offset, order_by: 'RCSID' })
+            .then((res) => {
+                const users = Array.isArray(res) ? (res as User[]) : [];
+                setAddUsersHasMore(users.length > ITEMS_PER_PAGE);
+                setAddUsersPageData(users.slice(0, ITEMS_PER_PAGE).map((activeUser) => ({
+                    id: activeUser.id,
+                    first_name: activeUser.first_name,
+                    last_name: activeUser.last_name,
+                    RCSID: activeUser.RCSID,
+                })));
+            })
+            .catch(() => {
+                setAddUsersPageData([]);
+                setAddUsersHasMore(false);
+            });
+    };
+
+    useEffect(() => {
+        if (!canSeeRoles) return;
+        void fetchRoles();
+    }, [canSeeRoles]);
+
+    useEffect(() => {
+        if (!canSeeUsers || !canSeeRoles) return;
+        fetchUsersForSelectedRole();
+    }, [canSeeUsers, canSeeRoles, selectedRoleId]);
+
+    useEffect(() => {
+        if (showAddUsersPanel && canSeeUsers) {
+            setAddUsersPageIndex(1);
+            fetchAddUsersPage(1);
+        }
+    }, [showAddUsersPanel, canSeeUsers]);
+
+    const onDelete = (index_local: number, index_real: number) => {
+        if (!canChangeUserRoles) {
+            alert('You do not have permissions to change user roles');
+            return;
+        }
+
+        const activeUser = assignedUsers[index_real];
+        if (!activeUser || !selectedRoleId) return;
+
+        OmniAPI.edit('roles', 'user', {
+            user_id: activeUser.id,
+            role_id: selectedRoleId,
+            should_have_role: false,
+        }).then(() => {
+            fetchUsersForSelectedRole();
+        }).catch(() => {
+            alert('Failed to remove role from user');
+        });
+    };
+
+    const onAdd = (activeUser: RoleUserRow) => {
+        if (!canChangeUserRoles) {
+            alert('You do not have permissions to change user roles');
+            return;
+        }
+        if (!selectedRoleId) return;
+
+        OmniAPI.edit('roles', 'user', {
+            user_id: activeUser.id,
+            role_id: selectedRoleId,
+            should_have_role: true,
+        }).then(() => {
+            fetchUsersForSelectedRole();
+            if (showAddUsersPanel) {
+                setAddUsersPageIndex(1);
+                fetchAddUsersPage(1);
+            }
+        }).catch(() => {
+            alert('Failed to add role to user');
+        });
+    };
+
+    // user search
+    const assignedUserIds = new Set(assignedUsers.map((activeUser) => activeUser.id));
+    const normalizedSearchQuery = userSearchQuery.trim().toLowerCase();
+
+    const filteredAddUsers = addUsersPageData
+        .filter((activeUser) => {
+            if (!normalizedSearchQuery) return true;
+            return [activeUser.first_name, activeUser.last_name, activeUser.RCSID]
+                .some((value) => value.toLowerCase().includes(normalizedSearchQuery));
+        })
+        .map((activeUser) => {
+            if (!normalizedSearchQuery) {
+                return { activeUser, score: 0 };
+            }
+
+            const firstName = activeUser.first_name.toLowerCase();
+            const lastName = activeUser.last_name.toLowerCase();
+            const rcsid = activeUser.RCSID.toLowerCase();
+
+            let score = 3;
+            if (rcsid === normalizedSearchQuery || firstName === normalizedSearchQuery || lastName === normalizedSearchQuery) {
+                score = 0;
+            } else if (rcsid.startsWith(normalizedSearchQuery) || firstName.startsWith(normalizedSearchQuery) || lastName.startsWith(normalizedSearchQuery)) {
+                score = 1;
+            } else if (rcsid.includes(normalizedSearchQuery)) {
+                score = 2;
+            }
+
+            return { activeUser, score };
+        })
+        .sort((left, right) => {
+            if (left.score !== right.score) return left.score - right.score;
+
+            const leftName = `${left.activeUser.first_name} ${left.activeUser.last_name} ${left.activeUser.RCSID}`.toLowerCase();
+            const rightName = `${right.activeUser.first_name} ${right.activeUser.last_name} ${right.activeUser.RCSID}`.toLowerCase();
+            return leftName.localeCompare(rightName);
+        })
+        .map(({ activeUser }) => activeUser);
+
+    const handlePreviousAddUsersPage = () => {
+        if (addUsersPageIndex === 1) return;
+        const newPage = addUsersPageIndex - 1;
+        setAddUsersPageIndex(newPage);
+        fetchAddUsersPage(newPage);
+    };
+
+    const handleNextAddUsersPage = () => {
+        if (!addUsersHasMore) return;
+        const newPage = addUsersPageIndex + 1;
+        setAddUsersPageIndex(newPage);
+        fetchAddUsersPage(newPage);
+    };
+
+    if (!canSeeRoles || !canSeeUsers) return null;
+
+    return (
+        <div className='tab-column-cover align-center'>
+            <TableHead heading='User Roles' />
+            <div className='Fieldset' style={{ width: '100%', maxWidth: '1100px' }}>
+                <label className='Label' htmlFor='role-select'>Role</label>
+                <select
+                    className='Input'
+                    id='role-select'
+                    value={selectedRoleId}
+                    onChange={(e) => setSelectedRoleId(e.target.value)}
+                >
+                    <option value='' disabled>Select a role</option>
+                    {allRoles.map((activeRole) => (
+                        <option key={activeRole.id} value={activeRole.id}>
+                            {activeRole.name}
+                        </option>
+                    ))}
+                </select>
+
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <label className='Label' style={{ marginBottom: 0 }}>Users</label>
+                    {canChangeUserRoles && (
+                        <button className='addbtn' type='button' onClick={() => setShowAddUsersPanel(true)}>
+                            <PlusIcon />
+                        </button>
+                    )}
+                </div>
+
+                <Table<RoleUserRow>
+                    columns={['first_name', 'last_name', 'RCSID']}
+                    data={assignedUsers}
+                    onDelete={canChangeUserRoles ? onDelete : undefined}
+                />
+            </div>
+
+            <Dialog.Root open={showAddUsersPanel} onOpenChange={setShowAddUsersPanel}>
+                <Dialog.Portal>
+                    <div className='AEdiv'>
+                        <Dialog.Overlay className='DialogOverlay' />
+                        <Dialog.Content className='DialogContent' aria-describedby={undefined}>
+                            <Dialog.Close asChild>
+                                <button className='IconButton' aria-label='Close'>
+                                    <Cross2Icon />
+                                </button>
+                            </Dialog.Close>
+                            <Dialog.Title className='DialogTitle'>Add Users to Role</Dialog.Title>
+                            <fieldset className='Fieldset'>
+                                <label className='Label' htmlFor='user-search'>Search</label>
+                                <input
+                                    id='user-search'
+                                    className='Input'
+                                    value={userSearchQuery}
+                                    onChange={(e) => {
+                                        setUserSearchQuery(e.target.value);
+                                        setAddUsersPageIndex(1);
+                                        fetchAddUsersPage(1);
+                                    }}
+                                    placeholder='Search by first name, last name, or RCSID'
+                                />
+                                <label className='Label'>Users</label>
+                                <div className='table-container' style={{ marginTop: '0.25rem', padding: 0, maxHeight: '30vh' }}>
+                                    <table>
+                                        <thead>
+                                            <tr>
+                                                <th>First Name</th>
+                                                <th>Last Name</th>
+                                                <th>RCSID</th>
+                                                <th></th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {filteredAddUsers.length > 0 ? filteredAddUsers.map((activeUser) => (
+                                                <tr key={activeUser.id}>
+                                                    <td>{activeUser.first_name}</td>
+                                                    <td>{activeUser.last_name}</td>
+                                                    <td>{activeUser.RCSID}</td>
+                                                    <td style={{ textAlign: 'center' }}>
+                                                        {assignedUserIds.has(activeUser.id) ? '' : (
+                                                            <button
+                                                                className='Button SaveBtn'
+                                                                type='button'
+                                                                onClick={() => onAdd(activeUser)}
+                                                            >
+                                                                Add
+                                                            </button>
+                                                        )}
+                                                    </td>
+                                                </tr>
+                                            )) : (
+                                                <tr>
+                                                    <td colSpan={4} style={{ textAlign: 'center' }}>No users are present.</td>
+                                                </tr>
+                                            )}
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <div className='pagination-container'>
+                                    <div className='pagination'>
+                                        <button onClick={handlePreviousAddUsersPage} disabled={addUsersPageIndex === 1} aria-label='Previous page'>
+                                            <ArrowLeftIcon />
+                                        </button>
+
+                                        <button className='active' aria-current='page'>
+                                            {addUsersPageIndex}
+                                        </button>
+
+                                        <button onClick={handleNextAddUsersPage} disabled={!addUsersHasMore} aria-label='Next page'>
+                                            <ArrowRightIcon />
+                                        </button>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </Dialog.Content>
+                    </div>
+                </Dialog.Portal>
+            </Dialog.Root>
+        </div>
+    );
+};
+
+export default UserRoles;

--- a/frontend/src/components/MyForge/tabs/UserRoles.tsx
+++ b/frontend/src/components/MyForge/tabs/UserRoles.tsx
@@ -278,7 +278,7 @@ const UserRoles: React.FC = () => {
                                                     <td style={{ textAlign: 'center' }}>
                                                          {!assignedUserIds.has(activeUser.id) && (
                                                             <button
-                                                                className='Button SaveBtn'
+                                                                className='Button'
                                                                 type='button'
                                                                 onClick={() => onAdd(activeUser)}
                                                             >

--- a/frontend/src/components/MyForge/tabs/UserRoles.tsx
+++ b/frontend/src/components/MyForge/tabs/UserRoles.tsx
@@ -234,6 +234,7 @@ const UserRoles: React.FC = () => {
                     columns={['first_name', 'last_name', 'RCSID']}
                     data={assignedUsers}
                     onDelete={canChangeUserRoles ? onDelete : undefined}
+                    canDelete={canChangeUserRoles}
                 />
             </div>
 

--- a/frontend/src/components/MyForge/tabs/UserRoles.tsx
+++ b/frontend/src/components/MyForge/tabs/UserRoles.tsx
@@ -280,7 +280,7 @@ const UserRoles: React.FC = () => {
                                                     <td>{activeUser.last_name}</td>
                                                     <td>{activeUser.RCSID}</td>
                                                     <td style={{ textAlign: 'center' }}>
-                                                        {assignedUserIds.has(activeUser.id) ? '' : (
+                                                         {!assignedUserIds.has(activeUser.id) && (
                                                             <button
                                                                 className='Button SaveBtn'
                                                                 type='button'

--- a/frontend/src/components/MyForge/tabs/UserRoles.tsx
+++ b/frontend/src/components/MyForge/tabs/UserRoles.tsx
@@ -13,11 +13,7 @@ import '../styles/TabStyles.scss';
 type RoleUserRow = Pick<User, 'id' | 'first_name' | 'last_name' | 'RCSID'>;
 
 const UserRoles: React.FC = () => {
-    const { user } = useAuth();
-
-    const hasPermission = (permission: UserPermission) => (
-        user.permissions.includes(permission) || user.permissions.includes(UserPermission.IS_SUPERUSER)
-    );
+    const { hasPermission } = useAuth();
 
     const canSeeRoles = hasPermission(UserPermission.CAN_SEE_ROLES);
     const canSeeUsers = hasPermission(UserPermission.CAN_SEE_USERS);

--- a/frontend/src/components/MyForge/tabs/Users.tsx
+++ b/frontend/src/components/MyForge/tabs/Users.tsx
@@ -2,11 +2,16 @@ import React, { useState, useEffect } from 'react';
 import { OmniAPI } from 'src/apis/OmniAPI';
 import Table, { DeleteItem, ITEMS_PER_PAGE, TableHead } from '../components/Table';
 import { User } from 'src/interfaces';
+import { UserPermission } from 'src/enums';
+import useAuth from '../../Auth/useAuth';
 
 import '../styles/TabStyles.scss';
 
 
 const Users: React.FC = () => {
+
+    const { user } = useAuth();
+    const canSeeUsers = user.permissions.includes(UserPermission.CAN_SEE_USERS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
 
     const [data, setData] = React.useState<User[]>([]);
     //change this to fix gender id
@@ -31,6 +36,7 @@ const Users: React.FC = () => {
         DeleteItem('users', data[index_real], refreshPage);
     };
 
+    if (!canSeeUsers) return null;
     return (
         <div className='tab-column-cover align-center'>
             <TableHead

--- a/frontend/src/components/MyForge/tabs/Users.tsx
+++ b/frontend/src/components/MyForge/tabs/Users.tsx
@@ -10,8 +10,8 @@ import '../styles/TabStyles.scss';
 
 const Users: React.FC = () => {
 
-    const { user } = useAuth();
-    const canSeeUsers = user.permissions.includes(UserPermission.CAN_SEE_USERS) || user.permissions.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
+    const canSeeUsers = hasPermission(UserPermission.CAN_SEE_USERS);
 
     const [data, setData] = React.useState<User[]>([]);
     //change this to fix gender id

--- a/frontend/src/components/Status/components/Toolbar.tsx
+++ b/frontend/src/components/Status/components/Toolbar.tsx
@@ -54,9 +54,7 @@ const ActiveFilters = styled.div`
 
 const Toolbar: React.FC<ToolbarProps> = ({highlightFailed, setHighlightFailed, activeFilters, setActiveFilters}) => {
 
-    const { user } = useAuth();
-    const hasPermission = (permission: UserPermission) => 
-        user?.permissions?.includes(permission) || user?.permissions?.includes(UserPermission.IS_SUPERUSER);
+    const { hasPermission } = useAuth();
    
     const navigate = useNavigate();
 

--- a/frontend/src/interfaces.tsx
+++ b/frontend/src/interfaces.tsx
@@ -138,6 +138,15 @@ export interface Semester {
     calendar_year: number;
 }
 
+export interface Role {
+    id: string;
+    name: string;
+    permissions: UserPermission[];
+    inverse_permissions: UserPermission[];
+    display_role: boolean;
+    priority: number;
+}
+
 export interface ResourceSlot {
     id: string;
     name: string;


### PR DESCRIPTION
Added a Roles page so roles have CRUD, and made an assigning page so Users can now be assigned roles (Issue https://github.com/BreadInvasion/forge-new-website/issues/30). I decided to make a separate page for this feature instead of putting it in Users or Roles since it'll be used more often than roles will be edited. And there's a solid amount of functionality needed for the assignment dialog that I think should be kept modular.

Great news is that we can now see that the role permissions work because we can login as different roles!

## Endpoints:
I added seven endpoints to the backend to get this functionality. Five so that Roles now have CRUD functionality, one for changing a user's role, and one to return all the users for a given role

**All Role CRUD:**
I implemented create, edit, delete, get by id, and get all endpoints for Roles, as those had not existed previously. I followed the structure of all the other python endpoints, so it fits into the existing design, and did as much testing as I could to make sure all of these work correctly. These should obey all permissions, and fit with the pagination structure of the tables.

**Change User Role:**
This endpoint takes in a user id, role id, and a boolean `should_have_role`: true for adding the role to the user if they dont have it, and false to remove the role if they do have it.

**See Users For a Role:**
I decided to add this endpoint that allows you to get users that have a specific role, as there will be many users, but only some we care about, and especially with the pagination, this makes way more sense to do on the backend than to filter on the frontend.

## Roles Page:

**Roles Table:**
Here is the roles page (which was the reason the cell-scroll bar #42 happened). This has the same pagination, add, edit, and delete as all the other object pages, and obeys user permissions. I have roles sorted by priority.
<img width="1905" height="810" alt="image" src="https://github.com/user-attachments/assets/d51f9391-230a-4ab7-a187-90a256e2cec4" />

**Role Create/Edit Dialog:**
I have all the permissions listed with Y or N checkboxes to put each into permissions or inverse permissions (clicking one checkbox checks it and unchecks its inverse if it had been checked). It has the same Save button at the bottom of the dialog as every other create/edit dialog.
<img width="664" height="835" alt="image" src="https://github.com/user-attachments/assets/07c8dc84-f9c9-4983-bf9e-c2f6574b6e47" />

## Role Assignment:

**Dropdown:**
Roles are pulled dynamically and are in a dropdown. User selects which role they want to focus on, and then the Table below shows up with all the users who currently have that role. 
<img width="1488" height="641" alt="image" src="https://github.com/user-attachments/assets/574c24ce-7cbd-467b-9117-f7f894efa341" />

**Removing people from roles:**
Reusing the same hover-visible delete button as on all the other Table pages allows you to remove a role from a user who already has it
<img width="1492" height="631" alt="image" src="https://github.com/user-attachments/assets/1b3aca54-f69e-45b1-858f-5b610fa8dcf8" />

**Adding people to roles**
When the + button is clicked, a dialog shows up specific to that role. A table with pagination shows up, with "Add" on users who don't have that role yet, and a blank for users who have it already. The pagination won't be used much since this also includes a search feature - which searched on first name, last name, and RCSID
<img width="751" height="702" alt="image" src="https://github.com/user-attachments/assets/ba308b71-dc7f-40af-ba12-b408e2615459" />
<img width="680" height="560" alt="image" src="https://github.com/user-attachments/assets/254d9874-bccf-4cad-8190-b4acf0033351" />
<img width="639" height="671" alt="image" src="https://github.com/user-attachments/assets/5c323ce5-3091-481b-8b75-bd72c65f2fbf" />